### PR TITLE
Ensure payload is not null

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,7 +1,8 @@
 runtime: custom
 env: flex
 resources:
-  cpu: 1
-  memory_gb: 3
+  cpu: 2
+  memory_gb: 4
 automatic_scaling:
   min_num_instances: 1
+  max_num_instances: 4

--- a/src/cache.js
+++ b/src/cache.js
@@ -72,7 +72,7 @@ class Cache {
           const headers = JSON.parse(results[0].headers);
           response.set(headers);
           let payload = JSON.parse(results[0].payload);
-          if (typeof(payload) == 'object' && payload.type == 'Buffer')
+          if (payload && typeof(payload) == 'object' && payload.type == 'Buffer')
             payload = new Buffer(payload);
           response.send(payload);
           return;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -112,13 +112,18 @@ class Renderer {
       Emulation.setVirtualTimePolicy({policy: 'pauseIfNetworkFetchesPending', budget: currentTimeBudget});
 
       let budgetExpired = async() => {
-        let result = await Runtime.evaluate({expression: `(${getStatusCode.toString()})()`});
-        // Original status codes which aren't either 200 or 304 always return with that
-        // status code, regardless of meta tags.
-        if ((statusCode == 200 || statusCode == 304) && result.result.value)
-          statusCode = result.result.value;
+        try {
+          let result = await Runtime.evaluate({expression: `(${getStatusCode.toString()})()`});
+          // Original status codes which aren't either 200 or 304 always return with that
+          // status code, regardless of meta tags.
+          if ((statusCode == 200 || statusCode == 304) && result.result.value)
+            statusCode = result.result.value;
 
-        resolve({status: statusCode || 200});
+          resolve({status: statusCode || 200});
+        } catch (err) {
+          reject(err);
+        }
+
         budgetExpired = () => {};
         clearTimeout(timeoutId);
       };


### PR DESCRIPTION
Getting a lot of `TypeError: Cannot read property 'type' of null` errors

```
TypeError: Cannot read property 'type' of null
at Cache.<anonymous> (/app/src/cache.js:75)
at <anonymous>
at process._tickCallback (next_tick.js:188)
```
When payload is `null`, this will be true `typeof(payload) == 'object'`, `payload.type == 'Buffer'` will be executed and hence it will throw an error.