### PR TITLE
Bypass certificate errors

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -41,10 +41,19 @@ class Renderer {
     }
 
     return new Promise(async(resolve, reject) => {
-      const {Page, Runtime, Network, Emulation, Console} = client;
+      const {Page, Security, Runtime, Network, Emulation, Console} = client;
+
+      Security.certificateError(({eventId}) => {
+        Security.handleCertificateError({
+            eventId,
+            action: 'continue'
+        });
+      });
 
       await Promise.all([
         Page.enable(),
+        Security.enable(),
+        Security.setOverrideCertificateErrors({override: true}),
         Runtime.enable(),
         Console.enable(),
         Network.enable(),


### PR DESCRIPTION
See:

https://github.com/cyrus-and/chrome-remote-interface/wiki/Bypass-certificate-errors-(%22Your-connection-is-not-private%22)

Note that it does not address the case in which the remote server uses (optional) client certs.
This usually manifests itself as a log message `{ message: 'net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED' }`.

See:

https://bugs.chromium.org/p/chromium/issues/detail?id=758452