### PR TITLE
Fix middleware to set query parameter to "wc-inject-shadydom=true"

### DIFF
--- a/middleware/src/middleware.js
+++ b/middleware/src/middleware.js
@@ -96,7 +96,7 @@ module.exports.makeMiddleware = function(options) {
         req.protocol + '://' + req.get('host') + req.originalUrl;
     let renderUrl = proxyUrl + encodeURIComponent(incomingUrl);
     if (injectShadyDom) {
-      renderUrl += '?wc-inject-shadydom';
+      renderUrl += '?wc-inject-shadydom=true';
     }
     request({url: renderUrl, timeout}, (e) => {
       if (e) {

--- a/middleware/test/middleware-test.js
+++ b/middleware/test/middleware-test.js
@@ -109,7 +109,7 @@ test('adds shady dom parameter', async (t) => {
 
   const res = await get(bot, appUrl, '/foo');
   t.is(res.status, 200);
-  t.is(res.text, 'proxy ' + appUrl + '/foo?wc-inject-shadydom');
+  t.is(res.text, 'proxy ' + appUrl + '/foo?wc-inject-shadydom=true');
 });
 
 test('excludes static file paths by default', async (t) => {


### PR DESCRIPTION
The query parameter to enable Shady DOM for web components v1 is `wc-inject-shadydom=true`. Without setting to `true` `render-tron` won't work.

This works: http://render-tron.appspot.com/render/https://polymer-shop.appspot.com/?wc-inject-shadydom=true

Fixes https://github.com/GoogleChrome/rendertron/issues/81

