### PR TITLE
fix: clean errors, add validation & reduce exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+yarn.lock

--- a/src/index.html
+++ b/src/index.html
@@ -206,6 +206,6 @@ the License.
     }
     </script>
 
-    <link rel="import" href="node_modules/progress-bar-element/progress-bar.html">
+    <link rel="import" href="progress-bar.html">
   </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -144,7 +144,7 @@ if (ENVIRONMENT === 'development') {
   });
 }
 
-app.stop = async () => {
+app.stop = async() => {
   await config.chrome.kill();
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -139,10 +139,14 @@ app.get('/_ah/health', (request, response) => response.send('OK'));
 // only expose chrome disable in development
 if (ENVIRONMENT === 'development') {
   app.get('/_ah/stop', async(request, response) => {
-    await config.chrome.kill();
+    await app.stop();
     response.send('OK');
   });
 }
+
+app.stop = async () => {
+  await config.chrome.kill();
+};
 
 const appPromise = chromeLauncher.launch({
   chromeFlags: ['--headless', '--disable-gpu', '--remote-debugging-address=0.0.0.0'],
@@ -176,7 +180,7 @@ async function logUncaughtError(error) {
   if (exceptionCount > 5) {
     console.log(`Detected ${exceptionCount} errors, shutting instance down`);
     if (config && config.chrome)
-      await config.chrome.kill();
+      await app.stop();
     process.exit(1);
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,6 @@ const app = express();
 const CONFIG_PATH = path.resolve(__dirname, '../config.json');
 const PROGRESS_BAR_PATH = path.resolve(__dirname, '../node_modules/progress-bar-element/progress-bar.html');
 const PORT = process.env.PORT || '3000';
-const ENVIRONMENT = process.env.NODE_ENV;
 
 let config = {};
 
@@ -137,14 +136,6 @@ app.get('/screenshot/:url(*)', async(request, response) => {
 });
 
 app.get('/_ah/health', (request, response) => response.send('OK'));
-
-// only expose chrome disable in development
-if (ENVIRONMENT === 'development') {
-  app.get('/_ah/stop', async(request, response) => {
-    await app.stop();
-    response.send('OK');
-  });
-}
 
 app.stop = async() => {
   await config.chrome.kill();

--- a/src/main.js
+++ b/src/main.js
@@ -17,24 +17,30 @@
 'use strict';
 
 const assert = require('assert');
-const renderer = require('./renderer');
-const chromeLauncher = require('chrome-launcher');
-const express = require('express');
 const fs = require('fs');
-const compression = require('compression');
-const path = require('path');
 const https = require('https');
-const app = express();
-const cache = require('./cache');
+const path = require('path');
+const url = require('url');
+const chromeLauncher = require('chrome-launcher');
+const compression = require('compression');
+const express = require('express');
 const now = require('performance-now');
 const uuidv4 = require('uuid/v4');
+const cache = require('./cache');
+const renderer = require('./renderer');
+
+const app = express();
+
+const CONFIG_PATH = path.resolve(__dirname, '../config.json');
+const PROGRESS_BAR_PATH = path.resolve(__dirname, '../node_modules/progress-bar-element/progress-bar.html');
+const PORT = process.env.PORT || '3000';
+const ENVIRONMENT = process.env.NODE_ENV;
+
+let config = {};
 
 // Load config from config.json if it exists.
-let config = {};
-const configPath = path.resolve(__dirname, '../config.json');
-
-if (fs.existsSync(configPath)) {
-  config = JSON.parse(fs.readFileSync(configPath));
+if (fs.existsSync(CONFIG_PATH)) {
+  config = JSON.parse(fs.readFileSync(CONFIG_PATH));
   assert(config instanceof Object);
 }
 
@@ -55,21 +61,24 @@ app.setConfig = (newConfig) => {
 };
 
 app.use(compression());
-
-app.use('/node_modules', express.static(path.resolve(__dirname, '../node_modules')));
+app.use('/progress-bar.html', express.static(PROGRESS_BAR_PATH));
 
 app.get('/', (request, response) => {
   response.sendFile(path.resolve(__dirname, 'index.html'));
 });
 
-function isRestricted(url) {
-  if (!config['renderOnly'])
-    return false;
+function isRestricted(urlReq) {
+  const protocol = (url.parse(urlReq).protocol || '');
+
+  if (!protocol.match(/^https?/)) return true;
+  if (!config['renderOnly']) return false;
+
   for (let i = 0; i < config['renderOnly'].length; i++) {
-    if (url.startsWith(config['renderOnly'][i])) {
+    if (urlReq.startsWith(config['renderOnly'][i])) {
       return false;
     }
   }
+
   return true;
 }
 
@@ -99,11 +108,8 @@ app.get('/render/:url(*)', async(request, response) => {
     const result = await renderer.serialize(request.params.url, request.query, config);
     response.status(result.status).send(result.body);
     track('render', now() - start);
-  } catch (err) {
-    let message = `Cannot render ${request.params.url}`;
-    if (err && err.message)
-      message += ` - "${err.message}"`;
-    response.status(400).send(message);
+  } catch (_) {
+    response.status(400).send('Cannot render requested URL');
   }
 });
 
@@ -124,19 +130,19 @@ app.get('/screenshot/:url(*)', async(request, response) => {
     response.end(img);
     track('screenshot', now() - start);
   } catch (err) {
-    let message = `Cannot render ${request.params.url}`;
-    if (err && err.message)
-      message += ` - "${err.message}"`;
-    response.status(400).send(message);
+    response.status(400).send('Cannot render requested URL');
   }
 });
 
 app.get('/_ah/health', (request, response) => response.send('OK'));
 
-app.get('/_ah/stop', async(request, response) => {
-  await config.chrome.kill();
-  response.send('OK');
-});
+// only expose chrome disable in development
+if (ENVIRONMENT === 'development') {
+  app.get('/_ah/stop', async(request, response) => {
+    await config.chrome.kill();
+    response.send('OK');
+  });
+}
 
 const appPromise = chromeLauncher.launch({
   chromeFlags: ['--headless', '--disable-gpu', '--remote-debugging-address=0.0.0.0'],
@@ -147,10 +153,9 @@ const appPromise = chromeLauncher.launch({
   config.port = chrome.port;
   // Don't open a port when running from inside a module (eg. tests). Importing
   // module can control this.
-  const port = process.env.PORT || '3000';
   if (!module.parent) {
-    app.listen(port, function() {
-      console.log('Listening on port', port);
+    app.listen(PORT, function() {
+      console.log('Listening on port', PORT);
     });
   }
   return app;
@@ -162,6 +167,7 @@ const appPromise = chromeLauncher.launch({
 
 
 let exceptionCount = 0;
+
 async function logUncaughtError(error) {
   console.error('Uncaught exception');
   console.error(error);

--- a/src/main.js
+++ b/src/main.js
@@ -108,8 +108,9 @@ app.get('/render/:url(*)', async(request, response) => {
     const result = await renderer.serialize(request.params.url, request.query, config);
     response.status(result.status).send(result.body);
     track('render', now() - start);
-  } catch (_) {
+  } catch (err) {
     response.status(400).send('Cannot render requested URL');
+    console.error(err);
   }
 });
 
@@ -131,6 +132,7 @@ app.get('/screenshot/:url(*)', async(request, response) => {
     track('screenshot', now() - start);
   } catch (err) {
     response.status(400).send('Cannot render requested URL');
+    console.error(err);
   }
 });
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -26,8 +26,7 @@ class Renderer {
      */
     function getStatusCode() {
       const metaElement = document.querySelector('meta[name="render:status_code"]');
-      if (!metaElement)
-        return undefined;
+      if (!metaElement) return;
       return parseInt(metaElement.getAttribute('content')) || undefined;
     }
 

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -26,7 +26,6 @@ app.use(express.static(path.resolve(__dirname, 'resources')));
 
 const appInstances = [];
 const testBase = 'http://localhost:1234/';
-process.env.NODE_ENV = 'development';
 
 test.before(async(t) => {
   await app.listen(1234);
@@ -47,8 +46,9 @@ test.after.always(async(t) => {
 async function createServer(config) {
   delete require.cache[require.resolve('../src/main.js')];
   const app = await require('../src/main.js');
-  if (config) app.setConfig(config);
-  await appInstances.push(app);
+  if (config)
+    app.setConfig(config);
+  appInstances.push(app);
   return request(app);
 }
 

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -114,15 +114,15 @@ test('server status code should be forwarded', async(t) => {
 
 test('http status code should be able to be set via a meta tag', async(t) => {
   const server = await createServer();
-  const testFile = 'resources/http-meta-status-code.html';
-  const res = await server.get('/render/http://' + testFile + '?wc-inject-shadydom=true');
+  const testFile = 'http-meta-status-code.html';
+  const res = await server.get(`/render/${testBase}${testFile}?wc-inject-shadydom=true`);
   t.is(res.status, 400);
 });
 
 test('http status codes need to be respected from top to bottom', async(t) => {
   const server = await createServer();
-  const testFile = 'resources/http-meta-status-code-multiple.html';
-  const res = await server.get('/render/http://' + testFile + '?wc-inject-shadydom=true');
+  const testFile = 'http-meta-status-code-multiple.html';
+  const res = await server.get(`/render/${testBase}${testFile}?wc-inject-shadydom=true`);
   t.is(res.status, 401);
 });
 

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -28,11 +28,11 @@ const appInstances = [];
 const testBase = 'http://localhost:1234/';
 process.env.NODE_ENV = 'development';
 
-test.before(async t => {
+test.before(async(t) => {
   await app.listen(1234);
 });
 
-test.after.always(async t => {
+test.after.always(async(t) => {
   for (let app of appInstances) {
     app.stop();
   }

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -34,7 +34,7 @@ test.before(async(t) => {
 
 test.after.always(async(t) => {
   for (let app of appInstances) {
-    app.stop();
+    await app.stop();
   }
 });
 


### PR DESCRIPTION
This PR fixes a few issues listed below:

- changes errors to be more generic, removing extraneous information to user
- adds validation for urls to only originate from 'http' or 'https' protocols
- sorts requires by alphabetical (node, node_modules, project) order
- only exposes `/_ah/stop` if `NODE_ENV` is set to `development`
- only exposes `progress-bar.html` used in application