### PR TITLE
Use HTTPS when no protocol is provided

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -200,6 +200,13 @@ the License.
     function takeScreenshot(element) {
       if (!url.value)
         return;
+      
+      var httpRegex = /(http(s?))\:\/\//gi;
+
+      if(!httpRegex.test(url.value)) {
+        url.value = "https://" + url.value;
+      }
+
       element.classList.add('loading');
       document.querySelector('progress-bar').removeAttribute('hidden');
       window.location.href += `screenshot/${url.value.replace('?', '%3F')}?width=${window.innerWidth}&height=${window.innerHeight}`;

--- a/src/index.html
+++ b/src/index.html
@@ -204,7 +204,7 @@ the License.
       var httpRegex = /(http(s?))\:\/\//gi;
 
       if(!httpRegex.test(url.value)) {
-        url.value = "https://" + url.value;
+        url.value = 'https://' + url.value;
       }
 
       element.classList.add('loading');


### PR DESCRIPTION
Related to #77 

Changes done in:

- [src/index.html](https://github.com/GoogleChrome/rendertron/blob/master/src/index.html)

This change will append `https` if no protocol is given in the UI.