### PR TITLE
Set response headers to indicate renderer & cache status

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -71,6 +71,7 @@ class Cache {
         if (results[0].expires.getTime() >= new Date().getTime()) {
           const headers = JSON.parse(results[0].headers);
           response.set(headers);
+          response.set('x-rendertron-cached', results[0].saved.toUTCString());
           let payload = JSON.parse(results[0].payload);
           if (payload && typeof(payload) == 'object' && payload.type == 'Buffer')
             payload = new Buffer(payload);

--- a/src/main.js
+++ b/src/main.js
@@ -105,6 +105,7 @@ app.get('/render/:url(*)', async(request, response) => {
   try {
     const start = now();
     const result = await renderer.serialize(request.params.url, request.query, config);
+    response.set('x-renderer', 'rendertron');
     response.status(result.status).send(result.body);
     track('render', now() - start);
   } catch (err) {

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -63,6 +63,7 @@ test('renders basic script', async(t) => {
   const res = await server.get(`/render/${testBase}basic-script.html`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('document-title') != -1);
+  t.is(res.header['x-renderer'], 'rendertron');
 });
 
 test('renders script after page load event', async(t) => {

--- a/test/cache-test.js
+++ b/test/cache-test.js
@@ -47,6 +47,8 @@ test('caches content and serves same content on cache hit', async(t) => {
   res = await server.get('/?basictest');
   t.is(res.status, 200);
   t.is(res.text, 'Called ' + previousCount + ' times');
+  t.truthy(res.header['x-rendertron-cached']);
+  t.true(new Date(res.header['x-rendertron-cached']) <= new Date());
 
   res = await server.get('/?basictest');
   t.is(res.status, 200);


### PR DESCRIPTION
This change sets 2 additional headers:
 - `x-renderer` is set to `rendertron` for all responses served via rendertron.
 - `x-rendertron-cached` is set when the response is served from rendertron's cache. Its value is set to the time the cached response was created. Format is per `Date` general header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date).