### PR TITLE
Set device scale ratio to 1

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -231,7 +231,7 @@ class Renderer {
 
       const width = Math.min(2000, parseInt(options['width']) || 1000);
       const height = Math.min(2000, parseInt(options['height']) || 1000);
-      await Emulation.setDeviceMetricsOverride({width: width, height: height, mobile: true, deviceScaleFactor: 3.5, fitWindow: false, screenWidth: width, screenHeight: height});
+      await Emulation.setDeviceMetricsOverride({width: width, height: height, mobile: true, deviceScaleFactor: 1, fitWindow: false, screenWidth: width, screenHeight: height});
       await Emulation.setVisibleSize({width: width, height: height});
 
       try {


### PR DESCRIPTION
Fixes issues reported in #43. `--headless` doesn't have support for the GPU yet. As a result, in some cases, some buffer is being hit and the resulting screenshot is missing areas. This appears to be caused by a combination of high DPR, large dimensions, complex rendering (eg. images).

Reducing DPR to 1 alleviates this issue but presumably will not fix this issue until headless supports the GPU.