### PR TITLE
support thirdparty fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN /usr/local/bin/install_node '>=7.6'
 
 COPY . /app/
 
+ADD thirdfonts /usr/share/fonts/thirdfonts
+RUN fc-cache -fv
+
 # Add botrender as a user
 RUN groupadd -r botrender && useradd -r -g botrender -G audio,video botrender \
     && mkdir -p /home/botrender && chown -R botrender:botrender /home/botrender \


### PR DESCRIPTION
As you know, screenshot function maybe not work well on some web page which contains chinese characters or some others.

So I add Microsoft YaHei fonts to thirdfonts/ fold to support above-mentioned problem.
And anyone could add fonts to thirdfonts/ fold and rebuild docker image to make things work.

I hope you can adopt this ;)