### PR TITLE
Support query parameter "quality" when screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The `screenshot` endpoint can be used to verify that your page is rendering corr
 Available options:
  * `width` default `1000` - used to set the viewport width (max 2000)
  * `height` default `1000` - used to set the viewport height (max 2000)
+ * `quality` default `60` - used to set the quality of picture (max 100 and min 60)
 
 ## FAQ
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -265,12 +265,18 @@ class Renderer {
 
       const width = Math.min(2000, parseInt(options['width']) || 1000);
       const height = Math.min(2000, parseInt(options['height']) || 1000);
+
+      let quality = parseInt(options['quality']) || 60;
+
+      quality = Math.min(100, quality);
+      quality = Math.max(60, quality);
+
       await Emulation.setDeviceMetricsOverride({width: width, height: height, mobile: true, deviceScaleFactor: 1, fitWindow: false, screenWidth: width, screenHeight: height});
       await Emulation.setVisibleSize({width: width, height: height});
 
       try {
         await this._loadPage(client, url, options, config);
-        let {data} = await Page.captureScreenshot({format: 'jpeg', quality: 60});
+        let {data} = await Page.captureScreenshot({format: 'jpeg', quality: quality});
 
         await this.closeConnection(client.target.id, config.port);
         resolve(data);


### PR DESCRIPTION
I've tried rendertron these days and it works great. However, I find the quality of the screenshot is too low. So I add the query parameter quality to set the quality of the screenshot.