### PR TITLE
Disable sandbox when running headless chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile extending the generic Node image with application files for a
 # single application.
 FROM gcr.io/google_appengine/nodejs
-LABEL name="bot-render" \ 
+LABEL name="bot-render" \
       version="0.1" \
       description="Renders a webpage for bot consumption (not production ready)"
 

--- a/src/main.js
+++ b/src/main.js
@@ -157,7 +157,7 @@ app.stop = async() => {
 };
 
 const appPromise = chromeLauncher.launch({
-  chromeFlags: ['--headless', '--disable-gpu'],
+  chromeFlags: ['--headless'],
   port: 0
 }).then((chrome) => {
   console.log('Chrome launched with debugging on port', chrome.port);

--- a/src/main.js
+++ b/src/main.js
@@ -157,7 +157,7 @@ app.stop = async() => {
 };
 
 const appPromise = chromeLauncher.launch({
-  chromeFlags: ['--headless', '--disable-gpu', '--remote-debugging-address=0.0.0.0'],
+  chromeFlags: ['--headless', '--disable-gpu'],
   port: 0
 }).then((chrome) => {
   console.log('Chrome launched with debugging on port', chrome.port);

--- a/src/main.js
+++ b/src/main.js
@@ -157,7 +157,7 @@ app.stop = async() => {
 };
 
 const appPromise = chromeLauncher.launch({
-  chromeFlags: ['--headless'],
+  chromeFlags: ['--headless', '--no-sandbox'],
   port: 9222,
 }).then((chrome) => {
   console.log('Chrome launched with debugging on port', chrome.port);

--- a/src/main.js
+++ b/src/main.js
@@ -158,7 +158,7 @@ app.stop = async() => {
 
 const appPromise = chromeLauncher.launch({
   chromeFlags: ['--headless'],
-  port: 0
+  port: 9222,
 }).then((chrome) => {
   console.log('Chrome launched with debugging on port', chrome.port);
   config.chrome = chrome;

--- a/src/main.js
+++ b/src/main.js
@@ -157,8 +157,8 @@ app.stop = async() => {
 };
 
 const appPromise = chromeLauncher.launch({
-  chromeFlags: ['--headless', '--no-sandbox'],
-  port: 9222,
+  chromeFlags: ['--headless', '--no-sandbox', '--remote-debugging-address=0.0.0.0'],
+  port: 0
 }).then((chrome) => {
   console.log('Chrome launched with debugging on port', chrome.port);
   config.chrome = chrome;


### PR DESCRIPTION
Closes #111.

See https://github.com/Googlechrome/puppeteer/issues/290 on the same issue.

The `--disable-gpu` flag is no longer required on Linux and Mac OS. See crbug.com/737678 for more details.