### PR TITLE
Base ref when is relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ npm run start
 After installing docker, build and run the docker image
 ```bash
 docker build -t rendertron . --no-cache=true
-docker run -it -p 8080:8080 --name rendertron-container rendertron
+docker run -d -p 8080:8080 --name rendertron-container rendertron
 ```
 
 Load the homepage in any browser:

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -219,13 +219,13 @@ class Renderer {
      * @param {string} url - Requested URL to set as the base.
      */
     function injectBaseHref(url) {
-      const actuallyLocationUrl = window.location.protocol + "//" + window.location.host + "/"
+      const actuallyLocationUrl = window.location.protocol + '//' + window.location.host + '/';
       const firstBase = document.getElementsByTagName('base').length && document.getElementsByTagName('base')[0].href;
       if (firstBase && firstBase.search(actuallyLocationUrl) == 0) {
-        //It's base relative, relocate uri
+        // It's base relative, relocate uri
         const originalHost = url.substring(0, url.indexOf('/', 8));
-        const pathBase = firstBase.substring(firstBase.indexOf('/', 8))
-        document.getElementsByTagName('base')[0].href = originalHost + pathBase
+        const pathBase = firstBase.substring(firstBase.indexOf('/', 8));
+        document.getElementsByTagName('base')[0].href = originalHost + pathBase;
       }
       const base = document.createElement('base');
       base.setAttribute('href', url);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -240,7 +240,7 @@ class Renderer {
 
       try {
         let renderResult = await this._loadPage(client, url, options, config);
-        console.log("Chingo!!!")
+        
         await Runtime.evaluate({expression: `(${stripPage.toString()})()`});
         await Runtime.evaluate({expression: `(${injectBaseHref.toString()})('${url}')`});
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -240,7 +240,7 @@ class Renderer {
 
       try {
         let renderResult = await this._loadPage(client, url, options, config);
-        
+
         await Runtime.evaluate({expression: `(${stripPage.toString()})()`});
         await Runtime.evaluate({expression: `(${injectBaseHref.toString()})('${url}')`});
 


### PR DESCRIPTION
I'm using Angular with LocationPathStrategy (see: https: //codecraft.tv/courses/angular/routing/routing-strategies/#_pathlocationstrategy), that's why I need to use , when doing the render it takes the first staying in localhost: 3000 / and does not load the .css.

I know, it's a very special case, but I want to give it support.