### PR TITLE
Add an option to render as mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ Note: the user agent lists differ there.
 GET /render/<url>
 ```
 
-The `render` endpoint will render your page and serialize your page.
+The `render` endpoint will render your page and serialize your page. Options are
+specified as query parameters:
+ * `mobile` defaults to `false`. Enable by passing `?mobile` to request the
+  mobile version of your site.
 
 ### Screenshot
 ```
@@ -71,6 +74,8 @@ correctly.
 Both endpoints support the following query parameters:
  * `width` defaults to `1000` - specifies viewport width.
  * `height` defaults to `1000` - specifies viewport height.
+ * `mobile` defaults to `false`. Enable by passing `?mobile` to request the
+  mobile version of your site.
 
 Additional options are available as a JSON string in the `POST` body. See
 [Puppeteer documentation](https://github.com/GoogleChrome/puppeteer/blob/v1.6.0/docs/api.md#pagescreenshotoptions)

--- a/src/index.html
+++ b/src/index.html
@@ -179,9 +179,13 @@ the License.
       <i class="material-icons">photo_camera</i>
       <span>Take screenshot</span>
     </button>
-    <button onclick="render(this)">
+    <button onclick="render(this, false)">
       <i class="material-icons">cloud_upload</i>
       <span>Render &amp; serialize</span>
+    </button>
+    <button onclick="render(this, true)">
+      <i class="material-icons">cloud_upload</i>
+      <span>Render as mobile &amp; serialize</span>
     </button>
     <a href="https://github.com/GoogleChrome/rendertron" target="_blank">
       <button tabindex="-1">
@@ -192,7 +196,7 @@ the License.
   </div>
 
   <script>
-    function render(element) {
+    function render(element, isMobile) {
       if (!url.value) {
         onEmptyUrl();
         return;
@@ -200,7 +204,7 @@ the License.
 
       element.classList.add('loading');
       document.querySelector('progress-bar').removeAttribute('hidden');
-      window.location.href += `render/${url.value.replace('?', '%3F')}`;
+      window.location.href += `render/${url.value.replace('?', '%3F')}${isMobile ? '?mobile' : ''}`;
     }
 
     function takeScreenshot(element) {

--- a/src/index.html
+++ b/src/index.html
@@ -184,7 +184,7 @@ the License.
       <span>Render &amp; serialize</span>
     </button>
     <button onclick="render(this, true)">
-      <i class="material-icons">cloud_upload</i>
+      <i class="material-icons">mobile_friendly</i>
       <span>Render as mobile &amp; serialize</span>
     </button>
     <a href="https://github.com/GoogleChrome/rendertron" target="_blank">

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -88,7 +88,9 @@ export class Rendertron {
       return;
     }
 
-    const serialized = await this.renderer.serialize(url);
+    const mobileVersion = 'mobile' in ctx.query ? true : false;
+
+    const serialized = await this.renderer.serialize(url, mobileVersion);
     // Mark the response as coming from Rendertron.
     ctx.set('x-renderer', 'rendertron');
     ctx.status = serialized.status;
@@ -110,7 +112,10 @@ export class Rendertron {
       height: Number(ctx.query['height']) || 1000
     };
 
-    const img = await this.renderer.screenshot(url, dimensions, options);
+    const mobileVersion = 'mobile' in ctx.query ? true : false;
+
+    const img =
+        await this.renderer.screenshot(url, mobileVersion, dimensions, options);
     ctx.set('Content-Type', 'image/jpeg');
     ctx.set('Content-Length', img.length.toString());
     ctx.body = img;


### PR DESCRIPTION
For example, rendering youtube.com as mobile gives the mobile optimised experience:

![image](https://user-images.githubusercontent.com/787668/43222083-e3cf7108-9003-11e8-837c-e12326c83122.png)
