### PR TITLE
Do not strip all scripts

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -10,7 +10,7 @@ type ViewportDimensions = {
 };
 
 const MOBILE_USERAGENT =
-  'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.75 Mobile Safari/537.36';
+    'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.75 Mobile Safari/537.36';
 
 /**
  * Wraps Puppeteer's interface to Headless Chrome to expose high level rendering
@@ -24,7 +24,7 @@ export class Renderer {
   }
 
   async serialize(requestUrl: string, isMobile: boolean):
-    Promise<SerializedResponse> {
+      Promise<SerializedResponse> {
     /**
      * Executed on the page after the page has loaded. Strips script and
      * import tags to prevent further loading of resources.
@@ -61,7 +61,7 @@ export class Renderer {
 
     const page = await this.browser.newPage();
 
-    page.setViewport({ width: 1000, height: 1000, isMobile });
+    page.setViewport({width: 1000, height: 1000, isMobile});
 
     if (isMobile) {
       page.setUserAgent(MOBILE_USERAGENT);
@@ -71,7 +71,7 @@ export class Renderer {
     page.evaluateOnNewDocument('ShadyDOM = {force: true}');
     page.evaluateOnNewDocument('ShadyCSS = {shimcssproperties: true}');
 
-    let response: puppeteer.Response | null = null;
+    let response: puppeteer.Response|null = null;
     // Capture main frame response. This is used in the case that rendering
     // times out, which results in puppeteer throwing an error. This allows us
     // to return a partial response for what was able to be rendered in that
@@ -85,7 +85,7 @@ export class Renderer {
     try {
       // Navigate to page. Wait until there are no oustanding network requests.
       response = await page.goto(
-        requestUrl, { timeout: 10000, waitUntil: 'networkidle0' });
+          requestUrl, {timeout: 10000, waitUntil: 'networkidle0'});
     } catch (e) {
       console.error(e);
     }
@@ -94,7 +94,7 @@ export class Renderer {
       console.error('response does not exist');
       // This should only occur when the page is about:blank. See
       // https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md#pagegotourl-options.
-      return { status: 400, content: '' };
+      return {status: 400, content: ''};
     }
 
     // Set status to the initial server's response code. Check for a <meta
@@ -102,11 +102,11 @@ export class Renderer {
     // code.
     let statusCode = response.status();
     const newStatusCode =
-      await page
-        .$eval(
-          'meta[name="render:status_code"]',
-          (element) => parseInt(element.getAttribute('content') || ''))
-        .catch(() => undefined);
+        await page
+            .$eval(
+                'meta[name="render:status_code"]',
+                (element) => parseInt(element.getAttribute('content') || ''))
+            .catch(() => undefined);
     // On a repeat visit to the same origin, browser cache is enabled, so we may
     // encounter a 304 Not Modified. Instead we'll treat this as a 200 OK.
     if (statusCode === 304) {
@@ -123,34 +123,34 @@ export class Renderer {
     // Inject <base> tag with the origin of the request (ie. no path).
     const parsedUrl = url.parse(requestUrl);
     await page.evaluate(
-      injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}`);
+        injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}`);
 
     // Serialize page.
     const result = await page.evaluate('document.firstElementChild.outerHTML');
 
     await page.close();
-    return { status: statusCode, content: result };
+    return {status: statusCode, content: result};
   }
 
   async screenshot(
-    url: string,
-    isMobile: boolean,
-    dimensions: ViewportDimensions,
-    options?: object): Promise<Buffer> {
+      url: string,
+      isMobile: boolean,
+      dimensions: ViewportDimensions,
+      options?: object): Promise<Buffer> {
     const page = await this.browser.newPage();
 
     page.setViewport(
-      { width: dimensions.width, height: dimensions.height, isMobile });
+        {width: dimensions.width, height: dimensions.height, isMobile});
 
     if (isMobile) {
       page.setUserAgent(MOBILE_USERAGENT);
     }
 
-    await page.goto(url, { timeout: 10000, waitUntil: 'networkidle0' });
+    await page.goto(url, {timeout: 10000, waitUntil: 'networkidle0'});
 
     // Must be jpeg & binary format.
     const screenshotOptions =
-      Object.assign({}, options, { type: 'jpeg', encoding: 'binary' });
+        Object.assign({}, options, {type: 'jpeg', encoding: 'binary'});
     const buffer = await page.screenshot(screenshotOptions);
     return buffer;
   }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -30,7 +30,7 @@ export class Renderer {
      * import tags to prevent further loading of resources.
      */
     function stripPage() {
-      const elements = document.querySelectorAll('script, link[rel=import]');
+      const elements = document.querySelectorAll('script:not([type]), script[type~="javascript"], link[rel=import]');
       for (const e of Array.from(elements)) {
         e.remove();
       }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -30,6 +30,7 @@ export class Renderer {
      * import tags to prevent further loading of resources.
      */
     function stripPage() {
+      // Strip only script tags that contain JavaScript (either no type attribute or one that contains "javascript")
       const elements = document.querySelectorAll('script:not([type]), script[type~="javascript"], link[rel=import]');
       for (const e of Array.from(elements)) {
         e.remove();

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -10,7 +10,7 @@ type ViewportDimensions = {
 };
 
 const MOBILE_USERAGENT =
-    'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.75 Mobile Safari/537.36';
+  'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.75 Mobile Safari/537.36';
 
 /**
  * Wraps Puppeteer's interface to Headless Chrome to expose high level rendering
@@ -24,14 +24,14 @@ export class Renderer {
   }
 
   async serialize(requestUrl: string, isMobile: boolean):
-      Promise<SerializedResponse> {
+    Promise<SerializedResponse> {
     /**
      * Executed on the page after the page has loaded. Strips script and
      * import tags to prevent further loading of resources.
      */
     function stripPage() {
       // Strip only script tags that contain JavaScript (either no type attribute or one that contains "javascript")
-      const elements = document.querySelectorAll('script:not([type]), script[type~="javascript"], link[rel=import]');
+      const elements = document.querySelectorAll('script:not([type]), script[type*="javascript"], link[rel=import]');
       for (const e of Array.from(elements)) {
         e.remove();
       }
@@ -61,7 +61,7 @@ export class Renderer {
 
     const page = await this.browser.newPage();
 
-    page.setViewport({width: 1000, height: 1000, isMobile});
+    page.setViewport({ width: 1000, height: 1000, isMobile });
 
     if (isMobile) {
       page.setUserAgent(MOBILE_USERAGENT);
@@ -71,7 +71,7 @@ export class Renderer {
     page.evaluateOnNewDocument('ShadyDOM = {force: true}');
     page.evaluateOnNewDocument('ShadyCSS = {shimcssproperties: true}');
 
-    let response: puppeteer.Response|null = null;
+    let response: puppeteer.Response | null = null;
     // Capture main frame response. This is used in the case that rendering
     // times out, which results in puppeteer throwing an error. This allows us
     // to return a partial response for what was able to be rendered in that
@@ -85,7 +85,7 @@ export class Renderer {
     try {
       // Navigate to page. Wait until there are no oustanding network requests.
       response = await page.goto(
-          requestUrl, {timeout: 10000, waitUntil: 'networkidle0'});
+        requestUrl, { timeout: 10000, waitUntil: 'networkidle0' });
     } catch (e) {
       console.error(e);
     }
@@ -94,7 +94,7 @@ export class Renderer {
       console.error('response does not exist');
       // This should only occur when the page is about:blank. See
       // https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md#pagegotourl-options.
-      return {status: 400, content: ''};
+      return { status: 400, content: '' };
     }
 
     // Set status to the initial server's response code. Check for a <meta
@@ -102,11 +102,11 @@ export class Renderer {
     // code.
     let statusCode = response.status();
     const newStatusCode =
-        await page
-            .$eval(
-                'meta[name="render:status_code"]',
-                (element) => parseInt(element.getAttribute('content') || ''))
-            .catch(() => undefined);
+      await page
+        .$eval(
+          'meta[name="render:status_code"]',
+          (element) => parseInt(element.getAttribute('content') || ''))
+        .catch(() => undefined);
     // On a repeat visit to the same origin, browser cache is enabled, so we may
     // encounter a 304 Not Modified. Instead we'll treat this as a 200 OK.
     if (statusCode === 304) {
@@ -123,34 +123,34 @@ export class Renderer {
     // Inject <base> tag with the origin of the request (ie. no path).
     const parsedUrl = url.parse(requestUrl);
     await page.evaluate(
-        injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}`);
+      injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}`);
 
     // Serialize page.
     const result = await page.evaluate('document.firstElementChild.outerHTML');
 
     await page.close();
-    return {status: statusCode, content: result};
+    return { status: statusCode, content: result };
   }
 
   async screenshot(
-      url: string,
-      isMobile: boolean,
-      dimensions: ViewportDimensions,
-      options?: object): Promise<Buffer> {
+    url: string,
+    isMobile: boolean,
+    dimensions: ViewportDimensions,
+    options?: object): Promise<Buffer> {
     const page = await this.browser.newPage();
 
     page.setViewport(
-        {width: dimensions.width, height: dimensions.height, isMobile});
+      { width: dimensions.width, height: dimensions.height, isMobile });
 
     if (isMobile) {
       page.setUserAgent(MOBILE_USERAGENT);
     }
 
-    await page.goto(url, {timeout: 10000, waitUntil: 'networkidle0'});
+    await page.goto(url, { timeout: 10000, waitUntil: 'networkidle0' });
 
     // Must be jpeg & binary format.
     const screenshotOptions =
-        Object.assign({}, options, {type: 'jpeg', encoding: 'binary'});
+      Object.assign({}, options, { type: 'jpeg', encoding: 'binary' });
     const buffer = await page.screenshot(screenshotOptions);
     return buffer;
   }

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -95,9 +95,9 @@ test('script tags and link[rel=import] tags are stripped', async (t) => {
 test('script tags for JSON-LD are not stripped', async (t) => {
   const res = await server.get(`/render/${testBase}include-json-ld.html`);
   t.is(res.status, 200);
-  t.false(res.text.indexOf('script src') != -1);
-  t.true(res.text.indexOf('application/ld+json') != -1);
-  t.false(res.text.indexOf('javascript') != -1)
+  t.false(res.text.indexOf('script src') !== -1);
+  t.true(res.text.indexOf('application/ld+json') !== -1);
+  t.false(res.text.indexOf('javascript') !== -1);
 });
 
 test('server status code should be forwarded', async (t) => {

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -92,6 +92,16 @@ test('script tags and link[rel=import] tags are stripped', async (t) => {
   t.true(res.text.indexOf('element-text') != -1);
 });
 
+test('script tags for JSON-LD are not stripped', async (t) => {
+  const res = await server.get(`/render/${testBase}include-json-ld.html`);
+  t.is(res.status, 200);
+  t.false(res.text.indexOf('script src') != -1);
+  t.true(res.text.indexOf('injectedElement') != -1);
+  t.false(res.text.indexOf('link rel') != -1);
+  t.true(res.text.indexOf('element-text') != -1);
+  t.true(res.text.indexOf('application/ld+json') != -1);
+});
+
 test('server status code should be forwarded', async (t) => {
   const res = await server.get('/render/http://httpstat.us/404');
   t.is(res.status, 404);

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -14,13 +14,13 @@
  * the License.
  */
 
-import {test} from 'ava';
+import { test } from 'ava';
 import * as Koa from 'koa';
 import * as koaStatic from 'koa-static';
 import * as path from 'path';
 import * as request from 'supertest';
 
-import {Rendertron} from '../rendertron';
+import { Rendertron } from '../rendertron';
 
 const app = new Koa();
 app.use(koaStatic(path.resolve(__dirname, '../../test-resources')));
@@ -57,28 +57,28 @@ test('renders script after page load event', async (t) => {
 // yet injected properly.
 test.failing('renders shadow DOM - no polyfill', async (t) => {
   const res = await server.get(
-      `/render/${testBase}shadow-dom-no-polyfill.html?wc-inject-shadydom=true`);
+    `/render/${testBase}shadow-dom-no-polyfill.html?wc-inject-shadydom=true`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
 
 test('renders shadow DOM - polyfill loader', async (t) => {
   const res = await server.get(`/render/${
-      testBase}shadow-dom-polyfill-loader.html?wc-inject-shadydom=true`);
+    testBase}shadow-dom-polyfill-loader.html?wc-inject-shadydom=true`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
 
 test('renders shadow DOM - polyfill loader - different flag', async (t) => {
   const res = await server.get(
-      `/render/${testBase}shadow-dom-polyfill-loader.html?wc-inject-shadydom`);
+    `/render/${testBase}shadow-dom-polyfill-loader.html?wc-inject-shadydom`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
 
 test('renders shadow DOM - webcomponents-lite.js polyfill', async (t) => {
   const res = await server.get(`/render/${
-      testBase}shadow-dom-polyfill-all.html?wc-inject-shadydom=true`);
+    testBase}shadow-dom-polyfill-all.html?wc-inject-shadydom=true`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
@@ -96,10 +96,8 @@ test('script tags for JSON-LD are not stripped', async (t) => {
   const res = await server.get(`/render/${testBase}include-json-ld.html`);
   t.is(res.status, 200);
   t.false(res.text.indexOf('script src') != -1);
-  t.true(res.text.indexOf('injectedElement') != -1);
-  t.false(res.text.indexOf('link rel') != -1);
-  t.true(res.text.indexOf('element-text') != -1);
   t.true(res.text.indexOf('application/ld+json') != -1);
+  t.false(res.text.indexOf('javascript') != -1)
 });
 
 test('server status code should be forwarded', async (t) => {
@@ -111,14 +109,14 @@ test('server status code should be forwarded', async (t) => {
 test('http status code should be able to be set via a meta tag', async (t) => {
   const testFile = 'http-meta-status-code.html';
   const res = await server.get(
-      `/render/${testBase}${testFile}?wc-inject-shadydom=true`);
+    `/render/${testBase}${testFile}?wc-inject-shadydom=true`);
   t.is(res.status, 400);
 });
 
 test('http status codes need to be respected from top to bottom', async (t) => {
   const testFile = 'http-meta-status-code-multiple.html';
   const res = await server.get(
-      `/render/${testBase}${testFile}?wc-inject-shadydom=true`);
+    `/render/${testBase}${testFile}?wc-inject-shadydom=true`);
   t.is(res.status, 401);
 });
 
@@ -132,10 +130,10 @@ test('screenshot is an image', async (t) => {
 
 test('screenshot accepts options', async (t) => {
   const res =
-      await server.post(`/screenshot/${testBase}basic-script.html`).send({
-        clip: {x: 100, y: 100, width: 100, height: 100},
-        path: 'test.jpeg'
-      });
+    await server.post(`/screenshot/${testBase}basic-script.html`).send({
+      clip: { x: 100, y: 100, width: 100, height: 100 },
+      path: 'test.jpeg'
+    });
   t.is(res.status, 200);
   t.is(res.header['content-type'], 'image/jpeg');
   t.true(res.body.length > 300);

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -14,13 +14,13 @@
  * the License.
  */
 
-import { test } from 'ava';
+import {test} from 'ava';
 import * as Koa from 'koa';
 import * as koaStatic from 'koa-static';
 import * as path from 'path';
 import * as request from 'supertest';
 
-import { Rendertron } from '../rendertron';
+import {Rendertron} from '../rendertron';
 
 const app = new Koa();
 app.use(koaStatic(path.resolve(__dirname, '../../test-resources')));
@@ -57,28 +57,28 @@ test('renders script after page load event', async (t) => {
 // yet injected properly.
 test.failing('renders shadow DOM - no polyfill', async (t) => {
   const res = await server.get(
-    `/render/${testBase}shadow-dom-no-polyfill.html?wc-inject-shadydom=true`);
+      `/render/${testBase}shadow-dom-no-polyfill.html?wc-inject-shadydom=true`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
 
 test('renders shadow DOM - polyfill loader', async (t) => {
   const res = await server.get(`/render/${
-    testBase}shadow-dom-polyfill-loader.html?wc-inject-shadydom=true`);
+      testBase}shadow-dom-polyfill-loader.html?wc-inject-shadydom=true`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
 
 test('renders shadow DOM - polyfill loader - different flag', async (t) => {
   const res = await server.get(
-    `/render/${testBase}shadow-dom-polyfill-loader.html?wc-inject-shadydom`);
+      `/render/${testBase}shadow-dom-polyfill-loader.html?wc-inject-shadydom`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
 
 test('renders shadow DOM - webcomponents-lite.js polyfill', async (t) => {
   const res = await server.get(`/render/${
-    testBase}shadow-dom-polyfill-all.html?wc-inject-shadydom=true`);
+      testBase}shadow-dom-polyfill-all.html?wc-inject-shadydom=true`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
@@ -109,14 +109,14 @@ test('server status code should be forwarded', async (t) => {
 test('http status code should be able to be set via a meta tag', async (t) => {
   const testFile = 'http-meta-status-code.html';
   const res = await server.get(
-    `/render/${testBase}${testFile}?wc-inject-shadydom=true`);
+      `/render/${testBase}${testFile}?wc-inject-shadydom=true`);
   t.is(res.status, 400);
 });
 
 test('http status codes need to be respected from top to bottom', async (t) => {
   const testFile = 'http-meta-status-code-multiple.html';
   const res = await server.get(
-    `/render/${testBase}${testFile}?wc-inject-shadydom=true`);
+      `/render/${testBase}${testFile}?wc-inject-shadydom=true`);
   t.is(res.status, 401);
 });
 
@@ -130,10 +130,10 @@ test('screenshot is an image', async (t) => {
 
 test('screenshot accepts options', async (t) => {
   const res =
-    await server.post(`/screenshot/${testBase}basic-script.html`).send({
-      clip: { x: 100, y: 100, width: 100, height: 100 },
-      path: 'test.jpeg'
-    });
+      await server.post(`/screenshot/${testBase}basic-script.html`).send({
+        clip: {x: 100, y: 100, width: 100, height: 100},
+        path: 'test.jpeg'
+      });
   t.is(res.status, 200);
   t.is(res.header['content-type'], 'image/jpeg');
   t.true(res.body.length > 300);

--- a/test-resources/include-json-ld.html
+++ b/test-resources/include-json-ld.html
@@ -32,4 +32,8 @@ the License.
     }
 }
 </script>
+<script type="text/javascript"> /* ... */</script>
+<script type="application/javascript"> /* ... */</script>
+<script type="application/x-javascript"> /* ... */ </script>
+<script> /* ... */</script>
 <custom-element></custom-element>

--- a/test-resources/include-json-ld.html
+++ b/test-resources/include-json-ld.html
@@ -1,0 +1,35 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<script src="inject-element-after-load.js"></script>
+<link rel="import" href="custom-element.html">
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org/",
+    "@type": "Product",
+    "name": "Executive Anvil",
+    "image": [
+        "https://example.com/photos/1x1/photo.jpg",
+        "https://example.com/photos/4x3/photo.jpg",
+        "https://example.com/photos/16x9/photo.jpg"
+        ],
+    "description": "Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveler looking for something to drop from a height.",
+    "brand": {
+        "@type": "Thing",
+        "name": "ACME"
+    }
+}
+</script>
+<custom-element></custom-element>


### PR DESCRIPTION
When using [Structured Data](https://developers.google.com/search/docs/guides/intro-structured-data) I noticed that Rendertron by default strips **all** script tags, no matter what they contain. I think it should not strip all script tags, because there might be reasons to have script tags that aren't JavaScript in your sources.

I made my patch a little broader, i.e. it conserves all scripts that aren't JavaScript. It only strips scripts without a `type` attribute or a `type` attribute that contains "javascript". If you think this is too broad, I'd be happy to narrow it down to exclude scripts of the type `application/ld+json` as that's the edge case I care most about.

Let me know what you think!