### PR TITLE
Added back a Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+node_modules
+.dockerignore
+Dockerfile
+npm-debug.log
+yarn-error.log
+.git
+.hg
+.svn
+middleware

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:8-slim
+
+# See https://crbug.com/795759
+RUN apt-get update && apt-get install -yq libgconf-2-4
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update && apt-get install -y wget --no-install-recommends \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge --auto-remove -y curl \
+    && rm -rf /src/*.deb
+
+# It's a good idea to use dumb-init to help prevent zombie chrome processes.
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+COPY . /home/pptruser
+
+# Add user so we don't need --no-sandbox.
+RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+    && mkdir -p /home/pptruser/Downloads \
+    && chown -R pptruser:pptruser /home/pptruser
+
+# Run everything after as non-privileged user.
+USER pptruser
+
+# Set a working directory
+WORKDIR /home/pptruser
+ENV WORKDIR /home/pptruser
+
+# Run everything after as non-privileged user.
+USER pptruser
+
+RUN npm install || \
+    ((if [ -f npm-debug.log ]; then \
+    cat npm-debug.log; \
+    fi) && false)
+
+RUN npm run build
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
This adds a new Dockerfile to the project to replace the one that was removed in https://github.com/GoogleChrome/rendertron/pull/199.  I wasn't able to find an explanation of why the Dockerfile was removed, just that the project is switching to puppeteer.

This new Dockerfile is based off puppeteer's `node:8-slim` Dockerfile as documented [here](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker).  Note that with this Dockerfile, we shouldn't need to launch puppeteer with `--no-sandbox`. 

For the record, I tried to use the `node:9-alpine` as per the [documentation](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine) but there were some [issues](https://github.com/GoogleChrome/puppeteer/issues/3019).  Also, this project would have to honor a configurable option to pass in a custom chrome executable path.  

This PR is missing documentation updates with instructions on how to build the image as we used to have.  I'm hesitant on making those changes until a maintainer weighs in on why Docker support was removed in the first place.