### PR TITLE
Fix mobile rendering

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -61,7 +61,9 @@ export class Renderer {
 
     const page = await this.browser.newPage();
 
-    page.setViewport({width: 1000, height: 1000, isMobile});
+    // Page may reload when setting isMobile
+    // https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagesetviewportviewport
+    await page.setViewport({width: 1000, height: 1000, isMobile});
 
     if (isMobile) {
       page.setUserAgent(MOBILE_USERAGENT);
@@ -145,7 +147,9 @@ export class Renderer {
       options?: object): Promise<Buffer> {
     const page = await this.browser.newPage();
 
-    page.setViewport(
+    // Page may reload when setting isMobile
+    // https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagesetviewportviewport
+    await page.setViewport(
         {width: dimensions.width, height: dimensions.height, isMobile});
 
     if (isMobile) {


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/rendertron/issues/233.

The page may reload when setting the `isMobile` property on `page.setViewport` according to the [docs](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagesetviewportviewport). This can be visually verified when launching `puppeteer` in non-headless mode - the page rendered is `about:blank`, resulting in the 400 error.