### PR TITLE
Always close page before return to prevent memory leak

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -96,12 +96,14 @@ export class Renderer {
       console.error('response does not exist');
       // This should only occur when the page is about:blank. See
       // https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md#pagegotourl-options.
+      await page.close();
       return {status: 400, content: ''};
     }
 
     // Disable access to compute metadata. See
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response.headers()['metadata-flavor'] === 'Google') {
+      await page.close();
       return {status: 403, content: ''};
     }
 


### PR DESCRIPTION
This PR fixes possible memory leak when renderer returns early after found an error. The page should be closed before every return to avoid a huge pile of unused pages.