### PR TITLE
Improves cache tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "monitor-inspect": "nodemon --inspect src/main.js",
     "test": "(cd test-resources && npm install) && npm run build && ava build/test/app-test.js --timeout 5s",
     "start-emulator": "(gcloud beta emulators datastore start --no-store-on-disk --project emulator-project --host-port localhost:8380 &) 2>&1 | grep -m1 'now running'",
-    "test-cache": "npm run start-emulator && $(gcloud beta emulators datastore env-init) && export GCLOUD_PROJECT=emulator-project && ava build/test/datastore-cache-test.js"
+    "test-cache": "npm run start-emulator && $(gcloud beta emulators datastore env-init) && export GCLOUD_PROJECT=emulator-project && ava build/test/*-cache-test.js"
   },
   "dependencies": {
     "@google-cloud/datastore": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "monitor": "nodemon",
     "monitor-inspect": "nodemon --inspect src/main.js",
     "test": "(cd test-resources && npm install) && npm run build && ava build/test/app-test.js --timeout 5s",
-    "start-emulator": "(gcloud beta emulators datastore start --no-store-on-disk --project emulator-project &) 2>&1 | grep -m1 'now running'",
-    "test-cache": "npm run start-emulator && $(gcloud beta emulators datastore env-init) && export GCLOUD_PROJECT='emulator-project' && ava build/test/datastore-cache-test.js"
+    "start-emulator": "(gcloud beta emulators datastore start --no-store-on-disk --project emulator-project --host-port localhost:8380 &) 2>&1 | grep -m1 'now running'",
+    "test-cache": "npm run start-emulator && $(gcloud beta emulators datastore env-init) && export GCLOUD_PROJECT=emulator-project && ava build/test/datastore-cache-test.js"
   },
   "dependencies": {
     "@google-cloud/datastore": "^1.4.2",

--- a/src/test/datastore-cache-test.ts
+++ b/src/test/datastore-cache-test.ts
@@ -56,7 +56,7 @@ test('caches content and serves same content on cache hit', async (t) => {
   t.is(res.text, 'Called ' + previousCount + ' times');
 
   // Workaround for race condition with writing to datastore.
-  await promiseTimeout(500);
+  await promiseTimeout(2000);
 
   res = await server.get('/?basictest');
   t.is(res.status, 200);


### PR DESCRIPTION
* The datastore emulator seems to work differently depending on the version of gcloud utils installed, so we specify the port.
* The datastore cache was flaky due to race conditions with the network operation to the gcloud datastore, so we increase the wait time.
* The `test-cache` task wasn't testing the in-memory cache, so we add it.