### PR TITLE
[Docs] Updated emojis

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@
 
 > Rendertron is a headless Chrome rendering solution designed to render & serialise web pages on the fly.
 
-- ![](https://github.githubassets.com/images/icons/emoji/unicode/1f528.png): Built with [Puppeteer](https://github.com/GoogleChrome/puppeteer)
-- ![](https://github.githubassets.com/images/icons/emoji/unicode/2601.png): Easy deployment to Google Cloud
-- ![](https://github.githubassets.com/images/icons/emoji/unicode/1f50d.png): Improves SEO
+- <a href="#"><img alt="hammer" class="emoji" src="https://github.githubassets.com/images/icons/emoji/unicode/1f528.png" height="20" width="20"></a> Built with [Puppeteer](https://github.com/GoogleChrome/puppeteer)
+- <a href="#"><img alt="cloud" class="emoji" src="https://github.githubassets.com/images/icons/emoji/unicode/2601.png" height="20" width="20"></a> Easy deployment to Google Cloud
+- <a href="#"><img alt="mag" class="emoji" src="https://github.githubassets.com/images/icons/emoji/unicode/1f50d.png" height="20" width="20"></a> Improves SEO
 
 Rendertron is designed to enable your Progressive Web App (PWA) to serve the correct
 content to any bot that doesn't render or execute JavaScript. Rendertron runs as a


### PR DESCRIPTION
There are a couple of issues here.

1. The `img` tag is being wrapped in an `a` tag. One way is to set `href` to `#` (which I've done).

2. When using the actual emoji, it is being replaced by an g-emoji element, which has its own styles plus it sets the height and width to '1rem'.

TLDR: The position and size is not absolutely same as the emoji.

Resolves #321 