### PR TITLE
Bug fix: read timeout from config instead of hard coded value

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -189,7 +189,7 @@ export class Renderer {
     try {
       // Navigate to page. Wait until there are no oustanding network requests.
       response =
-          await page.goto(url, {timeout: 10000, waitUntil: 'networkidle0'});
+          await page.goto(url, {timeout: this.config.timeout, waitUntil: 'networkidle0'});
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
Refere to [Issue 351](https://github.com/GoogleChrome/rendertron/issues/351) for more details.