### PR TITLE
Update App Engine from Node 8 to Node 12

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs8
+runtime: nodejs12
 instance_class: F4_1G
 automatic_scaling:
   min_instances: 1


### PR DESCRIPTION
Node 8 on App Engine is deprecated. 

Node 12 is the latest version, and should be GA soon.