### PR TITLE
Fix base url with using pathname

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -159,7 +159,7 @@ export class Renderer {
     // Inject <base> tag with the origin of the request (ie. no path).
     const parsedUrl = url.parse(requestUrl);
     await page.evaluate(
-        injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}`);
+        injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.pathname}`);
 
     // Serialize page.
     const result = await page.evaluate('document.firstElementChild.outerHTML') as string;


### PR DESCRIPTION
Base url used as root for relative paths and should contain whole path without query string.
E.g. there is `<link href="styles/widget.css" rel="stylesheet">` on page `https://example.tld/project/`. Relative link will be `https://example.tld/styles/widget.css` but should be `https://example.tld/project/styles/widget.css`
This works even if base url will be `https://example.tld/project/index.html`