### PR TITLE
added `keepScripts` URI param to leave scripts in the rendered output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ specified as query parameters:
   mobile version of your site.
  * `refreshCache`: Pass `refreshCache=true` to ignore potentially cached render results 
  and treat the request as if it is not cached yet. 
- The new render result is used to replace the previous result.  
+ The new render result is used to replace the previous result.
+ * `keepScripts`: By default rendered output doesn't contain scripts. Pass `?keepScripts` to keep 
+ javascripts intact.   
 
 ### Screenshot
 ```

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -29,7 +29,7 @@ export class Renderer {
     this.config = config;
   }
 
-  async serialize(requestUrl: string, isMobile: boolean, isStripPage: boolean):
+  async serialize(requestUrl: string, isMobile: boolean, isStripPage: boolean, waitForSelectorString: string | null):
       Promise<SerializedResponse> {
     /**
      * Executed on the page after the page has loaded. Strips script and
@@ -111,6 +111,11 @@ export class Renderer {
     if (response.headers()['metadata-flavor'] === 'Google') {
       await page.close();
       return {status: 403, customHeaders: new Map(), content: ''};
+    }
+
+    if (waitForSelectorString) {
+      // wait for html element to appear on the page before further processing
+      await page.waitForSelector(waitForSelectorString);
     }
 
     // Set status to the initial server's response code. Check for a <meta

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -29,7 +29,7 @@ export class Renderer {
     this.config = config;
   }
 
-  async serialize(requestUrl: string, isMobile: boolean):
+  async serialize(requestUrl: string, isMobile: boolean, isStripPage: boolean):
       Promise<SerializedResponse> {
     /**
      * Executed on the page after the page has loaded. Strips script and
@@ -155,7 +155,9 @@ export class Renderer {
         .catch(() => undefined);
 
     // Remove script & import tags.
-    await page.evaluate(stripPage);
+    if (isStripPage) {
+      await page.evaluate(stripPage);
+    }
     // Inject <base> tag with the origin of the request (ie. no path).
     const parsedUrl = url.parse(requestUrl);
     await page.evaluate(

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -92,8 +92,9 @@ export class Rendertron {
     }
 
     const mobileVersion = 'mobile' in ctx.query ? true : false;
+    const stripPage = 'keepScripts' in ctx.query ? false : true;
 
-    const serialized = await this.renderer.serialize(url, mobileVersion);
+    const serialized = await this.renderer.serialize(url, mobileVersion, stripPage);
 
     for (const key in this.config.headers) {
       ctx.set(key, this.config.headers[key]);

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -93,8 +93,9 @@ export class Rendertron {
 
     const mobileVersion = 'mobile' in ctx.query ? true : false;
     const stripPage = 'keepScripts' in ctx.query ? false : true;
+    const waitForSelectorString = ctx.query.waitForSelector || null;
 
-    const serialized = await this.renderer.serialize(url, mobileVersion, stripPage);
+    const serialized = await this.renderer.serialize(url, mobileVersion, stripPage, waitForSelectorString);
 
     for (const key in this.config.headers) {
       ctx.set(key, this.config.headers[key]);


### PR DESCRIPTION
Rendertron can be used for SSR. For this scenario we should leave scripts in the rendered output. Added keepScripts query param to enable this feature. By default, render endpoint falls back to the old behavior (strips all scripts)