### PR TITLE
Allows specifying puppeteer arguments in config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export type Config = {
     width: number;
     height: number;
     headers: { [key: string]: string };
+    puppeteerArgs: Array<string>;
 };
 
 export class ConfigManager {
@@ -43,7 +44,8 @@ export class ConfigManager {
         host: '0.0.0.0',
         width: 1000,
         height: 1000,
-        headers: {}
+        headers: {},
+        puppeteerArgs: [ '--no-sandbox' ]
     };
 
     static async getConfiguration(): Promise<Config> {

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -29,7 +29,7 @@ export class Rendertron {
     this.port = this.port || this.config.port;
     this.host = this.host || this.config.host;
 
-    const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+    const browser = await puppeteer.launch({ args: this.config.puppeteerArgs });
     this.renderer = new Renderer(browser, this.config);
 
     this.app.use(koaLogger());


### PR DESCRIPTION
Reworked @japboy's pull request to pass through puppeteer args via config.json.

Supersedes #279 