### PR TITLE
Fixes the link to CONTRIBUTING.md in the docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,4 +34,4 @@ are no uptime guarantees.
 - [Using Rendertron with your server](server-setup)
 -   [API Reference](api-reference)
 -   [Best practices](best_practices)
--   [Contributing to Rendertron](contributing)
+-   [Contributing to Rendertron](https://github.com/GoogleChrome/rendertron/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
The current landing page of the docs (https://googlechrome.github.io/rendertron/) had a broken link to the contributing documentation. This fixes that link :)