### PR TITLE
Fixes Filesystem cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - source $HOME/gcloud/google-cloud-sdk/path.bash.inc
   - (cd middleware && npm install)
   - mkdir ./tmp
-  - echo '{"cacheConfig": { "snapshotDir": "./tmp/rendertron" }}' > ./config.json
+  - echo '{"cacheConfig": { "snapshotDir": "./tmp/rendertron" } }' > ./config.json
 script:
   - npm run lint
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - (cd middleware && npm install)
   - mkdir ./tmp
   - >
-    echo '{"cache": { "snapShotDir": "./tmp/rendertron" } }' > ./config.json
+    echo '{"cacheConfig": { "snapshotDir": "./tmp/rendertron" } }' > ./config.json
 script:
   - npm run lint
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ install:
   - source $HOME/gcloud/google-cloud-sdk/path.bash.inc
   - (cd middleware && npm install)
   - mkdir ./tmp
-  - echo '{"cacheConfig": { "snapshotDir": "./tmp/rendertron" } }' > ./config.json
+  - >
+    echo '{"cache": { "snapShotDir": "./tmp/rendertron" } }' > ./config.json
 script:
   - npm run lint
   - npm run test

--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -47,14 +47,13 @@ export class FilesystemCache {
   constructor(config: Config) {
     this.config = config;
     this.cacheConfig = this.config.cacheConfig;
-
-    if (!fs.existsSync(this.getDir(''))) {
-      fs.mkdirSync(this.getDir(''), { recursive: true });
-    }
   }
 
   getDir = (key: string) => {
     const dir = this.cacheConfig.snapshotDir;
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
 
     if (key) {
       return path.join(dir, key);


### PR DESCRIPTION
The cache tests highlighted a fundamental robustness issue in the filesystem cache.
Only the constructor checks if the directory that the cache uses is present and creates directories if necessary.

When using clearAll, however, the directory is deleted. That's fine, but the next request fails as the cache directory is neither readable nor writable.

This PR fixes the problem by checking the directory on every request, re-creating it if it doesn't.
While this does incurr a bit of a runtime cost for looking up the filesystem, it makes Rendertron more robust against runtime failures when the directory gets deleted, either through `clearAllCache` or outside of the process.