### PR TITLE
Filesystem invalidate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ for available options. You cannot specify the `type` (defaults to `jpeg`) and
 GET /invalidate/<url>
 ```
 
-The `invalidate` endpoint will remove cache entried for `<url>` from the configured cache (in-memory or cloud datastore).
+The `invalidate` endpoint will remove cache entried for `<url>` from the configured cache (in-memory, filesystem or cloud datastore).
 
 ## FAQ
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -86,7 +86,7 @@ const screenshotOptions = Object.assign({}, options, {
 
 `/invalidate`
 
-Invalidate a cache entry from memory or cloud datastore.   
+Invalidate a cache entry from memory, filesystem or cloud datastore.   
 (Only available if cache is configured)
 
 | param  | type     | description                     |

--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -63,7 +63,6 @@ export class FilesystemCache {
   }
 
   async clearCache(key: string) {
-    console.log(path.join(this.getDir(''), key + '.json'));
     if (fs.existsSync(path.join(this.getDir(''), key + '.json'))) {
       fs.unlinkSync(path.join(this.getDir(''), key + '.json'));
     }

--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -155,6 +155,9 @@ export class FilesystemCache {
       cacheKey = cacheKey.slice(0, -1);
     }
 
+    // remove /invalidate/ from key
+    cacheKey = cacheKey.replace(/^\/invalidate\//, '');
+
     // remove trailing slash from key
     cacheKey = cacheKey.replace(/\/$/, '');
 

--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -155,9 +155,6 @@ export class FilesystemCache {
       cacheKey = cacheKey.slice(0, -1);
     }
 
-    // remove /render/ from key
-    cacheKey = cacheKey.replace(/^\/render\//, '');
-
     // remove trailing slash from key
     cacheKey = cacheKey.replace(/\/$/, '');
 

--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -74,7 +74,7 @@ export class FilesystemCache {
     fs.readdir(this.getDir(''), (err, files) => {
       if (err) throw err;
       for (const file of files) {
-        fs.unlink(path.join(this.getDir(''), file), err => {
+        fs.unlink(path.join(this.getDir(''), file), (err) => {
           if (err) throw err;
         });
       }

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -67,6 +67,8 @@ export class Rendertron {
       this.app.use(memoryCache.middleware());
     } else if (this.config.cache === 'filesystem') {
       const { FilesystemCache } = await import('./filesystem-cache');
+      const filesystemCache = new FilesystemCache(this.config);
+      this.app.use(route.get('/invalidate/:url(.*)', filesystemCache.invalidateHandler()));
       this.app.use(new FilesystemCache(this.config).middleware());
     }
 

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -30,6 +30,7 @@ app.use(koaStatic(path.resolve(__dirname, '../../test-resources')));
 const testBase = 'http://localhost:1234/';
 
 const rendertron = new Rendertron();
+
 let server: request.SuperTest<request.Test>;
 
 test.before(async () => {
@@ -293,7 +294,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t) 
   t.true(res.header['x-rendertron-cached'] != null);
 
   // Invalidate cache and ensure it is not cached
-  res = await cached_server.get(`/invalidate/${test_url}`);
+  res = await cached_server.get(`/invalidate/${testBase}basic-script.html`);
   res = await cached_server.get(test_url);
   t.is(res.status, 200);
   t.true(res.text.indexOf('document-title') !== -1);
@@ -301,6 +302,6 @@ test('endpont for invalidating filesystem cache works if configured', async (t) 
   t.true(res.header['x-rendertron-cached'] == null);
 
   // cleanup cache to prevent future tests failing
-  res = await cached_server.get(`/invalidate/${test_url}`);
+  res = await cached_server.get(`/invalidate/${testBase}basic-script.html`);
   fs.rmdirSync(path.join(os.tmpdir(), 'rendertron-test-cache'));
 });

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -220,7 +220,7 @@ test('endpont for invalidating memory cache works if configured', async (t) => {
     width: 1000,
     height: 1000,
     headers: {},
-    puppeteerArgs: ["--no-sandbox "]
+    puppeteerArgs: ['--no-sandbox']
   };
   const cached_server = request(await (new Rendertron()).initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;
@@ -263,7 +263,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t) 
     width: 1000,
     height: 1000,
     headers: {},
-    puppeteerArgs: ["--no-sandbox "]
+    puppeteerArgs: ['--no-sandbox']
   };
   const cached_server = request(await (new Rendertron()).initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -20,6 +20,7 @@ import * as koaStatic from 'koa-static';
 import * as path from 'path';
 import * as request from 'supertest';
 import * as fs from 'fs';
+import * as os from 'os';
 
 import { Rendertron } from '../rendertron';
 
@@ -254,7 +255,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t) 
     cacheConfig: {
       cacheDurationMinutes: '120',
       cacheMaxEntries: '50',
-      snapshotDir: './rendertron-test-cache'
+      snapshotDir: path.join(os.tmpdir(), 'rendertron-test-cache')
     },
     timeout: 10000,
     port: '3000',
@@ -291,5 +292,5 @@ test('endpont for invalidating filesystem cache works if configured', async (t) 
 
   // cleanup cache to prevent future tests failing
   res = await cached_server.get(`/invalidate/${test_url}`);
-  fs.rmdirSync('./rendertron-test-cache');
+  fs.rmdirSync(path.join(os.tmpdir(), 'rendertron-test-cache'));
 });

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -208,12 +208,14 @@ test('unknown url fails safely on screenshot', async (t) => {
 test('endpont for invalidating memory cache works if configured', async (t) => {
   const mock_config = {
     cache: 'memory' as const,
+    cacheConfig: {},
     timeout: 10000,
     port: '3000',
     host: '0.0.0.0',
     width: 1000,
     height: 1000,
-    headers: {}
+    headers: {},
+    puppeteerArgs: []
   };
   const cached_server = request(await (new Rendertron()).initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;

--- a/src/test/filesystem-cache-test.ts
+++ b/src/test/filesystem-cache-test.ts
@@ -16,13 +16,13 @@
 
 'use strict';
 
-import {test} from 'ava';
+import { test } from 'ava';
 import * as Koa from 'koa';
 import * as koaCompress from 'koa-compress';
 import * as request from 'supertest';
 import * as route from 'koa-route';
 
-import {FilesystemCache} from '../filesystem-cache';
+import { FilesystemCache } from '../filesystem-cache';
 import { ConfigManager } from '../config';
 
 const config = ConfigManager.config;
@@ -45,32 +45,28 @@ app.use(route.get('/', (ctx: Koa.Context) => {
   ctx.body = `Called ${handlerCalledCount} times`;
 }));
 
-const promiseTimeout = function(timeout: number) {
+const promiseTimeout = function (timeout: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, timeout);
   });
 };
 
 test('caches content and serves same content on cache hit', async (t) => {
-  let res = await server.get('/?basictest');
   const previousCount = handlerCalledCount;
+  let res = await server.get('/?basictest');
   t.is(res.status, 200);
-  t.is(res.text, 'Called ' + previousCount + ' times');
+  t.is(res.text, 'Called ' + (previousCount + 1) + ' times');
 
   // Workaround for race condition with writing to datastore.
   await promiseTimeout(2000);
 
   res = await server.get('/?basictest');
   t.is(res.status, 200);
-  t.is(res.text, 'Called ' + previousCount + ' times');
+  t.is(res.text, 'Called ' + (previousCount + 1) + ' times');
   t.truthy(res.header['x-rendertron-cached']);
   t.true(new Date(res.header['x-rendertron-cached']) <= new Date());
 
   res = await server.get('/?basictest');
-  t.is(res.status, 200);
-  t.is(res.text, 'Called ' + previousCount + ' times');
-
-  res = await server.get('/?basictest2');
   t.is(res.status, 200);
   t.is(res.text, 'Called ' + (previousCount + 1) + ' times');
 });
@@ -103,7 +99,7 @@ app.use(route.get('/compressed', (ctx: Koa.Context) => {
 test('compression preserved', async (t) => {
   const expectedBody = new Array(1025).join('x');
   let res = await server.get('/compressed')
-                .set('Accept-Encoding', 'gzip, deflate, br');
+    .set('Accept-Encoding', 'gzip, deflate, br');
   t.is(res.status, 200);
   t.is(res.header['content-encoding'], 'gzip');
   t.is(res.text, expectedBody);
@@ -112,7 +108,7 @@ test('compression preserved', async (t) => {
   await promiseTimeout(500);
 
   res = await server.get('/compressed')
-            .set('Accept-Encoding', 'gzip, deflate, br');
+    .set('Accept-Encoding', 'gzip, deflate, br');
   t.is(res.status, 200);
   t.is(res.header['content-encoding'], 'gzip');
   t.is(res.text, expectedBody);
@@ -137,6 +133,31 @@ test('original status is preserved', async (t) => {
   res = await server.get('/status/400');
   t.is(res.status, 401);
 });
+
+test('cache entry can be removed', async (t) => {
+  let res = await server.get('/?cacheremovetest');
+  t.is(res.status, 200);
+  t.falsy(res.header['x-rendertron-cached']);
+  t.false(new Date(res.header['x-rendertron-cached']) <= new Date());
+
+  res = await server.get('/?cacheremovetest');
+  t.is(res.status, 200);
+  t.truthy(res.header['x-rendertron-cached']);
+  t.true(new Date(res.header['x-rendertron-cached']) <= new Date());
+  const key = cache.hashCode('/?cacheremovetest');
+  cache.clearCache(key);
+  res = await server.get('/?cacheremovetest');
+  t.is(res.status, 200);
+  t.falsy(res.header['x-rendertron-cached']);
+  t.false(new Date(res.header['x-rendertron-cached']) <= new Date());
+
+  res = await server.get('/?cacheremovetest');
+  t.is(res.status, 200);
+  t.truthy(res.header['x-rendertron-cached']);
+  t.true(new Date(res.header['x-rendertron-cached']) <= new Date());
+
+});
+
 
 test('refreshCache refreshes cache', async (t) => {
   let content = 'content';


### PR DESCRIPTION
Addresses #420 

1.  Adds `/invalidate` handler to the filesystem cache
2. `README.md` & `docs/api-reference.md` amended
3. Test added

~~Question on the test, it created a folder in the same dir as the renderton install `./renderton-test-cache` and then removes this after the test has run, is this a legitimate way to do this?~~ changed to use os temp dir in ee7b4ba