### PR TITLE
Filesystem cache bug Fixed, additional logging added

### DIFF
--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -65,8 +65,17 @@ export class FilesystemCache {
   }
 
   async clearCache(key: string) {
-    if (fs.existsSync(path.join(this.getDir(''), key + '.json'))) {
-      fs.unlinkSync(path.join(this.getDir(''), key + '.json'));
+    let cleanKey = key;
+    if (!cleanKey.endsWith('.json')) {
+      cleanKey += '.json'
+    }
+    if (fs.existsSync(path.join(this.getDir(''), cleanKey))) {
+      try {
+        fs.unlinkSync(path.join(this.getDir(''), cleanKey));
+        console.log(`deleting: ${path.join(this.getDir(''), cleanKey)}`);
+      } catch (err) {
+        console.log(err);
+      }
     }
   }
 
@@ -107,7 +116,7 @@ export class FilesystemCache {
         dirsDate = dirsDate.slice(0, toRemove);
         dirsDate.forEach((rmDir) => {
           if (rmDir.fileName !== key + '.json') {
-            console.log(`removing cache: ${rmDir.fileName}`);
+            console.log(`max cache entries reached - removing: ${rmDir.fileName}`);
             this.clearCache(rmDir.fileName);
           }
         });

--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -67,7 +67,7 @@ export class FilesystemCache {
   async clearCache(key: string) {
     let cleanKey = key;
     if (!cleanKey.endsWith('.json')) {
-      cleanKey += '.json'
+      cleanKey += '.json';
     }
     if (fs.existsSync(path.join(this.getDir(''), cleanKey))) {
       try {


### PR DESCRIPTION
Fixes a bug where the filename to delete was sometime looking for `.json.json` instead of `.json`, should fix the issue reported in #430 

Also adds console.log() error reporting if the file fails to delete.