### PR TITLE
fixes <base ref="/" > being changed to origin & double slash

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -58,7 +58,12 @@ export class Renderer {
         // Patch existing <base> if it is relative.
         const existingBase = bases[0].getAttribute('href') || '';
         if (existingBase.startsWith('/')) {
-          bases[0].setAttribute('href', origin + existingBase);
+          // check if is only "/" if so add the origin only
+          if (existingBase === '/') {
+            bases[0].setAttribute('href', origin);
+          } else {
+            bases[0].setAttribute('href', origin + existingBase);
+          }
         }
       } else {
         // Only inject <base> if it doesn't already exist.


### PR DESCRIPTION
Sites that had a `<base href="/" >` were being rendered with `origin` & `//`  i.e. `<base href="https://example.com//" />`

Adds a check for the base href being only `"/"` and injects just `origin` if so.