### PR TITLE
Remove intermediary directory from base href

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -165,7 +165,7 @@ export class Renderer {
     // Inject <base> tag with the origin of the request (ie. no path).
     const parsedUrl = url.parse(requestUrl);
     await page.evaluate(
-      injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}${dirname(parsedUrl.pathname || '')}`);
+      injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}`);
 
     // Serialize page.
     const result = await page.content() as string;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -49,13 +49,12 @@ export class Renderer {
      * has no effect on serialised output, but allows it to verify render
      * quality.
      */
-    function injectBaseHref(parsedUrl: any) {
+    function injectBaseHref(origin: string, directory: string) {
 
       const bases = document.head.querySelectorAll('base');
       if (bases.length) {
         // Patch existing <base> if it is relative.
         const existingBase = bases[0].getAttribute('href') || '';
-        const origin = `${parsedUrl.protocol}//${parsedUrl.host}`
         if (existingBase.startsWith('/')) {
           // check if is only "/" if so add the origin only
           if (existingBase === '/') {
@@ -68,7 +67,7 @@ export class Renderer {
         // Only inject <base> if it doesn't already exist.
         const base = document.createElement('base');
         // Base url is the current directory
-        base.setAttribute('href', `${parsedUrl.protocol}//${parsedUrl.host}${dirname(parsedUrl.pathname || '')}`);  
+        base.setAttribute('href', origin + directory);  
         document.head.insertAdjacentElement('afterbegin', base);
       }
     }
@@ -166,8 +165,7 @@ export class Renderer {
     await page.evaluate(stripPage);
     // Inject <base> tag with the origin of the request (ie. no path).
     const parsedUrl = url.parse(requestUrl);
-    await page.evaluate(
-      injectBaseHref, parsedUrl);
+    await page.evaluate(injectBaseHref, `${parsedUrl.protocol}//${parsedUrl.host}`, `${dirname(parsedUrl.pathname || '')}`);
 
     // Serialize page.
     const result = await page.content() as string;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,6 +1,5 @@
 import * as puppeteer from 'puppeteer';
 import * as url from 'url';
-import { dirname } from 'path';
 
 import { Config } from './config';
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -67,7 +67,7 @@ export class Renderer {
         // Only inject <base> if it doesn't already exist.
         const base = document.createElement('base');
         // Base url is the current directory
-        base.setAttribute('href', origin + directory);  
+        base.setAttribute('href', origin + directory);
         document.head.insertAdjacentElement('afterbegin', base);
       }
     }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -67,6 +67,7 @@ export class Renderer {
       } else {
         // Only inject <base> if it doesn't already exist.
         const base = document.createElement('base');
+        // Base url is the current directory
         base.setAttribute('href', `${parsedUrl.protocol}//${parsedUrl.host}${dirname(parsedUrl.pathname || '')}`);  
         document.head.insertAdjacentElement('afterbegin', base);
       }

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -77,6 +77,19 @@ test('sets the correct base URL for the root folder', async (t) => {
   t.is(baseUrl, `${testBase}`);
 });
 
+test('sets the correct base URL for an already defined base as /', async (t) => {
+  const res = await server.get(`/render/${testBase}include-base.html`);
+  const matches = res.text.match('<base href="([^"]+)">');
+  const baseUrl = matches ? matches[1] : '';
+  t.is(baseUrl, `${testBase.slice(0, -1)}`);
+});
+
+test('sets the correct base URL for an already defined base as directory', async (t) => {
+  const res = await server.get(`/render/${testBase}include-base-as-directory.html`);
+  const matches = res.text.match('<base href="([^"]+)">');
+  const baseUrl = matches ? matches[1] : '';
+  t.is(baseUrl, `${testBase}dir1`);
+});
 
 // This test is failing as the polyfills (shady polyfill & scoping shim) are not
 // yet injected properly.

--- a/test-resources/include-base-as-directory.html
+++ b/test-resources/include-base-as-directory.html
@@ -1,0 +1,23 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<!DOCTYPE html>
+<html>
+    <head>
+        <base href="/dir1">
+    </head>    
+<body></body>
+
+</html>

--- a/test-resources/include-base.html
+++ b/test-resources/include-base.html
@@ -1,0 +1,23 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<!DOCTYPE html>
+<html>
+    <head>
+        <base href="/">
+    </head>    
+<body></body>
+
+</html>


### PR DESCRIPTION
Hello

I believe there is some inconsistency on the injectBaseHref function.
Let's assume that I have the base url defined as "/".

Then the following will happen when using rendertron:

- https://mywebsite.com -> base = https://mywebsite.com/ -> Ok
- https://mywebsite.com/dir1/page -> base = https://mywebsite.com/ -> Ok
- https://mywebsite.com/dir1/dir2/page -> base = https://mywebsite.com/dir1 -> **NOk**

I believe this is happening because the path.dirname(path) returns the directory of the path. In the last example the directory is /dir1/dir2. But the base url should be https://mywebsite.com/.

Hugo

