### PR TITLE
Setup official GitHub Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    versioning-strategy: increase
+  - package-ecosystem: 'npm'
+    directory: '/middleware/'
+    schedule:
+      interval: 'daily'
+    versioning-strategy: increase


### PR DESCRIPTION
Setup official GitHub Dependabot.

https://docs.github.com/en/github/administering-a-repository/about-github-dependabot-version-updates

> GitHub Dependabot takes the effort out of maintaining your dependencies. You can use it to ensure that your repository automatically keeps up with the latest releases of the packages and applications it depends on.

Then you will have a new tab `Dependabot` in the [`Insights > Dependency graph`](https://github.com/GoogleChrome/rendertron/network/dependencies) here:

https://github.com/GoogleChrome/rendertron/network/updates