### PR TITLE
feature: add reqHeaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ root. Available configuration options:
  * `host` _default `0.0.0.0`_ - set the hostname to use for running and listening the rendertron service. Note if process.env.HOST is set, it will be used instead.
  * `width` _default `1000`_ - set the width (resolution) to be used for rendering the page.
  * `height` _default `1000`_ - set the height (resolution) to be used for rendering the page.
+ * `reqHeaders` _default `{}`_ - set the additional HTTP headers to be sent to the target page with every request.
  * `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
  * `cacheConfig` - an object array to specify caching options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rendertron",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5670,11 +5670,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
-    },
-    "progress-bar-element": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress-bar-element/-/progress-bar-element-2.0.1.tgz",
-      "integrity": "sha1-6EkVNPGfyUlxBvMgxY7e0vCzI2c="
     },
     "prop-assign": {
       "version": "1.0.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export type Config = {
     host: string
     width: number;
     height: number;
+    reqHeaders: { [key: string]: string };
     headers: { [key: string]: string };
     puppeteerArgs: Array<string>;
 };
@@ -51,6 +52,7 @@ export class ConfigManager {
         host: '0.0.0.0',
         width: 1000,
         height: 1000,
+        reqHeaders: {},
         headers: {},
         puppeteerArgs: ['--no-sandbox']
     };

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -81,6 +81,8 @@ export class Renderer {
       page.setUserAgent(MOBILE_USERAGENT);
     }
 
+    await page.setExtraHTTPHeaders(this.config.reqHeaders);
+
     page.evaluateOnNewDocument('customElements.forcePolyfill = true');
     page.evaluateOnNewDocument('ShadyDOM = {force: true}');
     page.evaluateOnNewDocument('ShadyCSS = {shimcssproperties: true}');

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -230,6 +230,7 @@ test('endpont for invalidating memory cache works if configured', async (t) => {
     host: '0.0.0.0',
     width: 1000,
     height: 1000,
+    reqHeaders: {},
     headers: {},
     puppeteerArgs: ['--no-sandbox']
   };
@@ -273,6 +274,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t) 
     host: '0.0.0.0',
     width: 1000,
     height: 1000,
+    reqHeaders: {},
     headers: {},
     puppeteerArgs: ['--no-sandbox']
   };
@@ -304,4 +306,31 @@ test('endpont for invalidating filesystem cache works if configured', async (t) 
   // cleanup cache to prevent future tests failing
   res = await cached_server.get(`/invalidate/${testBase}basic-script.html`);
   fs.rmdirSync(path.join(os.tmpdir(), 'rendertron-test-cache'));
+});
+
+test('http header should be set via config', async (t) => {
+  const mock_config = {
+    cache: 'memory' as const,
+    cacheConfig: {
+      cacheDurationMinutes: '120',
+      cacheMaxEntries: '50'
+    },
+    timeout: 10000,
+    port: '3000',
+    host: '0.0.0.0',
+    width: 1000,
+    height: 1000,
+    // In request-header.html, any headers except referer cannot be shown
+    reqHeaders: {
+      'Referer': 'http://example.com/'
+    },
+    headers: {},
+    puppeteerArgs: ['--no-sandbox']
+  };
+  server = request(await rendertron.initialize(mock_config));
+  await app.listen(1237);
+  const res = await server.get(`/render/${testBase}request-header.html`);
+  console.log(res.text);
+  t.is(res.status, 200);
+  t.true(res.text.indexOf('http://example.com/') !== -1);
 });

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -330,7 +330,6 @@ test('http header should be set via config', async (t) => {
   server = request(await rendertron.initialize(mock_config));
   await app.listen(1237);
   const res = await server.get(`/render/${testBase}request-header.html`);
-  console.log(res.text);
   t.is(res.status, 200);
   t.true(res.text.indexOf('http://example.com/') !== -1);
 });

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -320,7 +320,6 @@ test('http header should be set via config', async (t) => {
     host: '0.0.0.0',
     width: 1000,
     height: 1000,
-    // In request-header.html, any headers except referer cannot be shown
     reqHeaders: {
       'Referer': 'http://example.com/'
     },

--- a/test-resources/request-header.html
+++ b/test-resources/request-header.html
@@ -1,0 +1,20 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<script>
+  var element = document.createElement('title');
+  element.textContent = document.referrer;
+  document.head.appendChild(element);
+</script>


### PR DESCRIPTION
## Why

Some users need to add some headers, for example, to access the restricted environment.
In my case, we need to add custom header to access the my environment.

## What

- Add `reqHeaders` in config
- Set the above header in puppeteer

