### PR TITLE
1 click Heroku deployment

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,19 @@
+{
+  "name": "Rendertron",
+  "description": "Rendertron is a headless Chrome rendering solution designed to render & serialise web pages on the fly.",
+  "keywords": [
+    "rendertron",
+    "render",
+    "web",
+    "chrome"
+  ],
+  "website": "https://github.com/GoogleChrome/rendertron",
+  "buildpacks": [
+    {
+      "url": "heroku/google-chrome"
+    },
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -27,6 +27,8 @@ Rendertron runs a server that takes a URL and returns static HTML for the URL by
 
 ###  Deploying Rendertron to Heroku
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://dashboard.heroku.com/new?button-url=https://github.com/GoogleChrome/rendertron/tree/main&template=https://github.com/GoogleChrome/rendertron/tree/main)
+
 Setup Herokuapp and Heroku CLI
 `https://devcenter.heroku.com/articles/heroku-cli`
 
@@ -39,7 +41,7 @@ $ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-google-chrome
 Next, add the `heroku/nodejs` buildpack to your project:
 
 ```
-$ heroku buildpacks:add heroku/nodejs -a <app-name>
+$ heroku buildpacks:add --index 2 heroku/nodejs -a <app-name>
 ```
 
 Then, update the `package.json` entry for `engines` to specific node and npm versions. I used:


### PR DESCRIPTION
Test the one click deployment here:
https://dashboard.heroku.com/new?button-url=https://github.com/NNTin/rendertron/tree/main&template=https://github.com/NNTin/rendertron/tree/main

I moved the button into docs/deploy.md. However the Heroku steps listed there are a bit faulty:

> First, add the Google Chrome buildpack to your project:
> 
> `$ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-google-chrome.git -a <app-name>`
> Next, add the heroku/nodejs buildpack to your project:
> 
> ~~`$ heroku buildpacks:add heroku/nodejs -a <app-name>`~~
> `$ heroku buildpacks:add --index 2 heroku/nodejs -a <app-name>`

explanation for `--index 2` follows below. This step is now automated via `app.json`. The buildpacks are automatically added via the Heroku dashboard/website/1-click deployment.

> Then, update the package.json entry for engines to specific node and npm versions. I used:
> 
> ```
> {
>   ...
>   "engines": {
>     "node": "10.15.1",
>     "npm": "6.4.1"
>   },
>   ...
> }
> ```
> This was helpful in getting past a node-gyp issue during npm install, which Heroku will run each time you deploy.

This is no longer necessary. Whatever fault existed was fixed.

> Next, enter a new script into your package.json:
> 
> ```
> {
>   "scripts": {
>     ...,
>     "heroku-postbuild": "npm run build"
>   }
> }
> ```
> This will make sure to build rendertron into bin/rendertron on each deploy, in case you have any local changes.

This step is not necessary because by default `npm build` is executed on each deploy. You can overwrite `npm build` with a Heroku specific one but for this build you don't need a custom build script.

> Finally, add a Procfile to your project with the following:
> 
> `web: node bin/rendertron`

This is not needed because by putting the nodejs buildpack second the process type is automatically defined.

> [The last buildpack in the list will be used to determine the process types for the application](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#viewing-buildpacks). Any process types defined from earlier buildpacks will be ignored.

And for a node js buildpack the default `Procfile` is `npm start` which translates to `node build/rendertron.js`.

With this you don't need to have the Heroku CLI installed, you don't need git and you also don't need a terminal. A temporary Heroku App instance is hosted here: https://protected-citadel-48851.herokuapp.com/ (I will destroy this app within a week because I am hosting other Heroku Apps and I rely on the free hours.)

The limitation of this PR is that an `app.json` is necessary on the root level of the git repo. I tried to remove any unnecessary files such as `Procfile` as well as any unnecessary changes to the `package.json`.  
With this it might be suitable to move the Heroku deploy link into the README.md but I leave it to the maintainers.