### PR TITLE
add timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Both endpoints support the following query parameters:
  * `height` defaults to `1000` - specifies viewport height.
  * `mobile` defaults to `false`. Enable by passing `?mobile` to request the
   mobile version of your site.
+ * `timezoneId` - specifies rendering for timezone.
 
 Additional options are available as a JSON string in the `POST` body. See
 [Puppeteer documentation](https://github.com/GoogleChrome/puppeteer/blob/v1.6.0/docs/api.md#pagescreenshotoptions)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -7,10 +7,11 @@
 
 Fetch and serialize a URL in headless Chrome.
 
-| param  | type     | description                     |
-| ------ | -------- | ------------------------------- |
-| `url`  | `String` | a valid URL to fetch            |
-| `opts` | `Object` | `Renderer` config class options |
+| param        | type     | description                     |
+| ------------ | -------- | ------------------------------- |
+| `url`        | `String` | a valid URL to fetch            |
+| `opts`       | `Object` | `Renderer` config class options |
+| `timezoneId` | `String` | specify timezoneId from [list](https://source.chromium.org/chromium/chromium/deps/icu.git/+/faee8bc70570192d82d2978a71e2a615788597d1:source/data/misc/metaZones.txt) with a querystring appended to the requested URL. |
 
 `/screenshot`
 
@@ -21,7 +22,8 @@ async screenshot(
     url: string,
     isMobile: boolean,
     dimensions: ViewportDimensions,
-    options?: object): Promise<Buffer>
+    options?: object,
+    timezoneId?: string): Promise<Buffer>
 }
 ```
 
@@ -31,6 +33,7 @@ async screenshot(
 | `isMobile`   | `Bool`                                      | Specify a mobile layout with a querystring automatically appended to the requested URL. |
 | `dimensions` | [`ViewportDimensions`](viewport-dimensions) | `height` and `width` specifications for the rendered page                               |
 | `options`    | `Object`                                    | define screenshot params                                                                |
+| `timezoneId` | `String`                                    | define timezoneId from [list](https://source.chromium.org/chromium/chromium/deps/icu.git/+/faee8bc70570192d82d2978a71e2a615788597d1:source/data/misc/metaZones.txt)|                                                             |
 
 `/invalidate/`
 

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -125,7 +125,7 @@ export class Rendertron {
 
     const mobileVersion = 'mobile' in ctx.query ? true : false;
 
-    const serialized = await this.renderer.serialize(url, mobileVersion);
+    const serialized = await this.renderer.serialize(url, mobileVersion, ctx.query.timezoneId);
 
     for (const key in this.config.headers) {
       ctx.set(key, this.config.headers[key]);
@@ -163,7 +163,7 @@ export class Rendertron {
 
     try {
       const img = await this.renderer.screenshot(
-        url, mobileVersion, dimensions, options);
+        url, mobileVersion, dimensions, options, ctx.query.timezoneId);
 
       for (const key in this.config.headers) {
         ctx.set(key, this.config.headers[key]);

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -214,7 +214,7 @@ test.failing('explicit render event ends early', async (t) => {
   t.true(res.text.indexOf('async loaded') !== -1);
 });
 
-test('whitelist ensures other urls do not get rendered', async(t) => {
+test('whitelist ensures other urls do not get rendered', async (t) => {
   const mock_config = {
     cache: 'memory' as const,
     cacheConfig: {
@@ -360,4 +360,21 @@ test('http header should be set via config', async (t) => {
   const res = await server.get(`/render/${testBase}request-header.html`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('http://example.com/') !== -1);
+});
+
+test('unknown timezone fails', async (t) => {
+  const res = await server.get(`/render/${testBase}include-date.html?timezoneId=invalid/timezone`);
+  t.is(res.status, 400);
+});
+
+test('known timezone applies', async (t) => {
+  // Atlantic/Reykjavik is a timezone where GMT+0 is all-year round without Daylight Saving Time
+  const res = await server.get(`/render/${testBase}include-date.html?timezoneId=Atlantic/Reykjavik`);
+  t.is(res.status, 200);
+  t.true(res.text.indexOf('00:00:00') !== -1);
+
+  const res2 = await server.get(`/render/${testBase}include-date.html?timezoneId=Australia/Perth`);
+  t.is(res2.status, 200);
+  // Australia/Perth is a timezone where GMT+8 is all-year round without Daylight Saving Time
+  t.true(res2.text.indexOf('08:00:00') !== -1);
 });

--- a/test-resources/include-date.html
+++ b/test-resources/include-date.html
@@ -1,0 +1,22 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<script>
+    window.onload = () => {
+        document.body.textContent = new Date(0).toString();
+        window.renderComplete = true;
+    };
+</script>


### PR DESCRIPTION
Add possibility to pass timezone from [timezones list](https://source.chromium.org/chromium/chromium/deps/icu.git/+/faee8bc70570192d82d2978a71e2a615788597d1:source/data/misc/metaZones.txt) to `/render` and `/screenshot` endpoints
