### PR TITLE
Update required version of Node in bin/rendertron

### DIFF
--- a/bin/rendertron
+++ b/bin/rendertron
@@ -6,8 +6,8 @@ process.title = 'rendertron';
 
 var semver = require('semver');
 
-if (!semver.satisfies(process.version, '>=7')) {
-  console.log('Rendertron requires Node 7+');
+if (!semver.satisfies(process.version, '>=10')) {
+  console.log('Rendertron requires Node 10+');
   process.exit(1);
 }
 


### PR DESCRIPTION
according to `package.json` (https://github.com/GoogleChrome/rendertron/blob/d1bcb13422395264f3f39aa2a1b5ec83438c681e/package.json#L8) Rendertron requires Node.js >= 10 to work, seems to be reasonble to bump its version in bin/rendertron