### PR TITLE
Add url blacklist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ root. Available configuration options:
  * `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
  * `cacheConfig` - an object array to specify caching options
  * `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
+ * `blacklist` - reject requests to a certain domain. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
 
 #### cacheConfig
 * `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -9,6 +9,7 @@ root. Available configuration options:
  * `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
  * `cacheConfig` - an object array to specify caching options
  * `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
+ * `blacklist` - reject requests to a certain domain. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
 
 ## cacheConfig
 * `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export type Config = {
     headers: { [key: string]: string };
     puppeteerArgs: Array<string>;
     renderOnly: Array<string>;
+    blacklist: Array<string>;
 };
 
 export class ConfigManager {
@@ -56,7 +57,8 @@ export class ConfigManager {
         reqHeaders: {},
         headers: {},
         puppeteerArgs: ['--no-sandbox'],
-        renderOnly: []
+        renderOnly: [],
+        blacklist: []
     };
 
     static async getConfiguration(): Promise<Config> {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -37,6 +37,12 @@ export class Renderer {
       return true;
     }
 
+    for (let i = 0; i < this.config.blacklist.length; i++) {
+      if (requestUrl.startsWith(this.config.blacklist[i])) {
+        return true;
+      }
+    }
+
     return false;
   }
 

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -100,17 +100,22 @@ export class Rendertron {
       return true;
     }
 
-    if (!this.config.renderOnly.length) {
-      return false;
+    if (this.config.renderOnly.length) {
+      for (let i = 0; i < this.config.renderOnly.length; i++) {
+        if (href.startsWith(this.config.renderOnly[i])) {
+          return false;
+        }
+      }
+      return true;
     }
 
-    for (let i = 0; i < this.config.renderOnly.length; i++) {
-      if (href.startsWith(this.config.renderOnly[i])) {
-        return false;
+    for (let i = 0; i < this.config.blacklist.length; i++) {
+      if (href.startsWith(this.config.blacklist[i])) {
+        return true;
       }
     }
 
-    return true;
+    return false;
   }
 
   async handleRenderRequest(ctx: Koa.Context, url: string) {


### PR DESCRIPTION
Same as https://github.com/GoogleChrome/rendertron/pull/475 and https://github.com/GoogleChrome/rendertron/pull/476
Blacklist functionality is intended to help with hardening Rendertron instance and prevent accessing sensitive endpoints.