### PR TITLE
Update new Buffer(...) to Buffer.from(...)

### DIFF
--- a/src/datastore-cache.ts
+++ b/src/datastore-cache.ts
@@ -139,7 +139,7 @@ export class DatastoreCache {
             let payload = JSON.parse(content.payload);
             if (payload && typeof (payload) === 'object' &&
               payload.type === 'Buffer') {
-              payload = new Buffer(payload);
+              payload = Buffer.from(payload);
             }
             ctx.body = payload;
             return;

--- a/src/memory-cache.ts
+++ b/src/memory-cache.ts
@@ -111,7 +111,7 @@ export class MemoryCache {
         let payload = JSON.parse(cachedContent.payload);
         if (payload && typeof (payload) === 'object' &&
           payload.type === 'Buffer') {
-          payload = new Buffer(payload);
+          payload = Buffer.from(payload);
         }
         ctx.body = payload;
         return;


### PR DESCRIPTION
As the Rendertron requires/forces Node.js version >= 10 to be used

https://github.com/GoogleChrome/rendertron/blob/d1bcb13422395264f3f39aa2a1b5ec83438c681e/package.json#L8
https://github.com/GoogleChrome/rendertron/blob/78492cc325a4022f2de27a1bbb0c84806afdd498/bin/rendertron#L9

I would like to propose moving from the deprecated `new Buffer(...)` to `Buffer.from(...)`

https://nodejs.org/dist/latest-v12.x/docs/api/buffer.html#buffer_static_method_buffer_from_array