### PR TITLE
Add this.browser.close() to force the browser to reconnect, fixes empty responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ root. Available configuration options:
  * `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
  * `cacheConfig` - an object array to specify caching options
  * `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
+ * `closeBrowser`_default `false` - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 
 #### cacheConfig
 * `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ root. Available configuration options:
  * `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
  * `cacheConfig` - an object array to specify caching options
  * `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
- * `closeBrowser`_default `false` - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
+ * `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 
 #### cacheConfig
 * `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -9,6 +9,7 @@ root. Available configuration options:
  * `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
  * `cacheConfig` - an object array to specify caching options
  * `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
+ * `closeBrowser`_default `false` - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 
 ## cacheConfig
 * `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -9,7 +9,7 @@ root. Available configuration options:
  * `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
  * `cacheConfig` - an object array to specify caching options
  * `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
- * `closeBrowser`_default `false` - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
+ * `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 
 ## cacheConfig
 * `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export type Config = {
     headers: { [key: string]: string };
     puppeteerArgs: Array<string>;
     renderOnly: Array<string>;
+    closeBrowser: boolean;
 };
 
 export class ConfigManager {
@@ -56,7 +57,8 @@ export class ConfigManager {
         reqHeaders: {},
         headers: {},
         puppeteerArgs: ['--no-sandbox'],
-        renderOnly: []
+        renderOnly: [],
+        closeBrowser: false
     };
 
     static async getConfiguration(): Promise<Config> {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -142,7 +142,9 @@ export class Renderer {
       // This should only occur when the page is about:blank. See
       // https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md#pagegotourl-options.
       await page.close();
-      await this.browser.close();
+      if (this.config.closeBrowser) {
+        await this.browser.close();
+      }
       return { status: 400, customHeaders: new Map(), content: '' };
     }
 
@@ -150,7 +152,9 @@ export class Renderer {
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response.headers()['metadata-flavor'] === 'Google') {
       await page.close();
-      await this.browser.close();
+      if (this.config.closeBrowser) {
+        await this.browser.close();
+      }
       return { status: 403, customHeaders: new Map(), content: '' };
     }
 
@@ -205,7 +209,9 @@ export class Renderer {
     const result = await page.content() as string;
 
     await page.close();
-    await this.browser.close();
+    if (this.config.closeBrowser) {
+      await this.browser.close();
+    }
     return { status: statusCode, customHeaders: customHeaders ? new Map(JSON.parse(customHeaders)) : new Map(), content: result };
   }
 
@@ -252,7 +258,9 @@ export class Renderer {
 
     if (!response) {
       await page.close();
-      await this.browser.close();
+      if (this.config.closeBrowser) {
+        await this.browser.close();
+      }
       throw new ScreenshotError('NoResponse');
     }
 
@@ -260,7 +268,9 @@ export class Renderer {
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response!.headers()['metadata-flavor'] === 'Google') {
       await page.close();
-      await this.browser.close();
+      if (this.config.closeBrowser) {
+        await this.browser.close();
+      }
       throw new ScreenshotError('Forbidden');
     }
 
@@ -271,7 +281,9 @@ export class Renderer {
     // https://github.com/GoogleChrome/puppeteer/blob/v1.8.0/docs/api.md#pagescreenshotoptions
     const buffer = await page.screenshot(screenshotOptions) as Buffer;
     await page.close();
-    await this.browser.close();
+    if (this.config.closeBrowser) {
+      await this.browser.close();
+    }
     return buffer;
   }
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -142,6 +142,7 @@ export class Renderer {
       // This should only occur when the page is about:blank. See
       // https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md#pagegotourl-options.
       await page.close();
+      await this.browser.close();
       return { status: 400, customHeaders: new Map(), content: '' };
     }
 
@@ -149,6 +150,7 @@ export class Renderer {
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response.headers()['metadata-flavor'] === 'Google') {
       await page.close();
+      await this.browser.close();
       return { status: 403, customHeaders: new Map(), content: '' };
     }
 
@@ -203,6 +205,7 @@ export class Renderer {
     const result = await page.content() as string;
 
     await page.close();
+    await this.browser.close();
     return { status: statusCode, customHeaders: customHeaders ? new Map(JSON.parse(customHeaders)) : new Map(), content: result };
   }
 
@@ -249,6 +252,7 @@ export class Renderer {
 
     if (!response) {
       await page.close();
+      await this.browser.close();
       throw new ScreenshotError('NoResponse');
     }
 
@@ -256,6 +260,7 @@ export class Renderer {
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response!.headers()['metadata-flavor'] === 'Google') {
       await page.close();
+      await this.browser.close();
       throw new ScreenshotError('Forbidden');
     }
 
@@ -266,6 +271,7 @@ export class Renderer {
     // https://github.com/GoogleChrome/puppeteer/blob/v1.8.0/docs/api.md#pagescreenshotoptions
     const buffer = await page.screenshot(screenshotOptions) as Buffer;
     await page.close();
+    await this.browser.close();
     return buffer;
   }
 }

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -227,7 +227,8 @@ test('whitelist ensures other urls do not get rendered', async (t: ExecutionCont
     reqHeaders: {},
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
-    renderOnly: [testBase]
+    renderOnly: [testBase],
+    closeBrowser: false
   };
   const server = request(await (new Rendertron()).initialize(mockConfig));
 
@@ -258,7 +259,8 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
     reqHeaders: {},
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
-    renderOnly: []
+    renderOnly: [],
+    closeBrowser: false
   };
   const cached_server = request(await (new Rendertron()).initialize(mockConfig));
   const test_url = `/render/${testBase}basic-script.html`;
@@ -303,7 +305,8 @@ test('endpont for invalidating filesystem cache works if configured', async (t: 
     reqHeaders: {},
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
-    renderOnly: []
+    renderOnly: [],
+    closeBrowser: false
   };
   const cached_server = request(await (new Rendertron()).initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;
@@ -352,7 +355,8 @@ test('http header should be set via config', async (t: ExecutionContext) => {
     },
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
-    renderOnly: []
+    renderOnly: [],
+    closeBrowser: false
   };
   server = request(await rendertron.initialize(mock_config));
   await app.listen(1237);
@@ -378,7 +382,8 @@ test.serial('endpoint for invalidating all memory cache works if configured', as
     },
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
-    renderOnly: []
+    renderOnly: [],
+    closeBrowser: false
   };
   const cached_server = request(await (new Rendertron()).initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;
@@ -425,7 +430,8 @@ test.serial('endpoint for invalidating all filesystem cache works if configured'
       'Referer': 'http://example.com/'
     },
     puppeteerArgs: ['--no-sandbox'],
-    renderOnly: []
+    renderOnly: [],
+    closeBrowser: false
   };
   const cached_server = request(await (new Rendertron()).initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;


### PR DESCRIPTION
Addresses #486 

Puppeteer returns null responses for page requests past the first one for some sites. The only reliable way to avoid this seems to be to disconnect from the browser and reconnect, the `createRender()` function on https://github.com/dwsmart/rendertron/blob/9bc42ddb6d3421152e9760b65cd8ffa752d71a82/src/rendertron.ts#L25 already reconnects with the required config if the browser disconnects, so calling `await this.browser.close();` after `await page.close();` fixes this issue, apparently with no massive performance hit.