### PR TITLE
Split tests in parallel jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,5 +54,22 @@ jobs:
       - name: Run the e2e cache tests
         run: npm run test-cache
 
-      - name: Run tests for the middleware
-        run: (cd middleware && npm run lint && npm run test)
+  test-middleware:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node: ['10', '12', '14']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: cd middleware/
+
+      - run: npm ci
+
+      - run: npm run test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,20 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - run: npm ci
+
+      - run: npm run lint
+
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
@@ -30,9 +44,6 @@ jobs:
           cd ./middleware && npm install
           mkdir ./tmp
           echo '{"cacheConfig": { "snapshotDir": "./tmp/rendertron" } }' > ./config.json
-
-      - name: Lint the source
-        run: npm run lint
 
       - name: Build Rendertron
         run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,30 +26,46 @@ jobs:
 
       - run: npm run lint
 
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  test:
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    strategy:
+      matrix:
+        node: ['10', '12', '14']
+
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-          npm install
-          export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-          sudo apt-get update && sudo apt-get install google-cloud-sdk google-cloud-sdk-datastore-emulator
-          cd ./middleware && npm install
-          mkdir ./tmp
-          echo '{"cacheConfig": { "snapshotDir": "./tmp/rendertron" } }' > ./config.json
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
 
-      - name: Build Rendertron
-        run: npm run build
+      - run: npm ci
 
       - name: Run the integration tests
         run: npm test
+
+  test-cache:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node: ['10', '12', '14']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+          sudo apt-get update && sudo apt-get install google-cloud-sdk google-cloud-sdk-datastore-emulator
+          mkdir ./tmp
+          echo '{"cacheConfig": { "snapshotDir": "./tmp/rendertron" } }' > ./config.json
 
       - name: Run the e2e cache tests
         run: npm run test-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint:
+    name: Lint
+
     runs-on: ubuntu-latest
 
     steps:
@@ -27,6 +29,8 @@ jobs:
       - run: npm run lint
 
   test:
+    name: Integration tests
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -42,10 +46,11 @@ jobs:
 
       - run: npm ci
 
-      - name: Run the integration tests
-        run: npm test
+      - run: npm test
 
   test-cache:
+    name: e2e cache tests
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -71,6 +76,8 @@ jobs:
         run: npm run test-cache
 
   test-middleware:
+    name: Middleware tests
+
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Now we have multiple parallel jobs:
- Run the linter
- Run the integration tests
- Run the cache tests (this is the longest, for needing to download dependencies)
- Run the middleware tests

Also testing in multiple node versions: 10, 12 & 14.

<img width="940" alt="Screenshot 2020-11-05 at 13 19 49" src="https://user-images.githubusercontent.com/1007051/98240381-9bbfd680-1f69-11eb-9b75-b4c5ed460dc8.png">
