### PR TITLE
Added config specify url restriction pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ root. Available configuration options:
 - `cacheConfig` - an object array to specify caching options
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
 - `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
+- `restrictedUrlPattern`_default `null`_ - set the restrictedUrlPattern to restrict the requests matching given regex pattern.
 
 #### cacheConfig
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export type Config = {
   puppeteerArgs: Array<string>;
   renderOnly: Array<string>;
   closeBrowser: boolean;
+  restrictedUrlPattern: string | null;
 };
 
 export class ConfigManager {
@@ -58,6 +59,7 @@ export class ConfigManager {
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
     closeBrowser: false,
+    restrictedUrlPattern: null
   };
 
   static async getConfiguration(): Promise<Config> {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -38,6 +38,10 @@ export class Renderer {
       return true;
     }
 
+    if (this.config.restrictedUrlPattern && requestUrl.match(new RegExp(this.config.restrictedUrlPattern))) {
+      return true;
+    }
+
     return false;
   }
 

--- a/test-resources/restrict-test.test.html
+++ b/test-resources/restrict-test.test.html
@@ -1,0 +1,20 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<script>
+  var element = document.createElement('title');
+  element.textContent = 'document' + '-title';
+  document.head.appendChild(element);
+</script>


### PR DESCRIPTION
This change adds request restriction based on a regex pattern. This pattern is specified in the config.
The following config would block the image requests.
```
{
  "restrictedUrlPattern": ".*(\\.png|\\.jpg|\\.gif|\\.webp)($|\\?)"
}
```
Example usage for this feature would be to block image requests since in some use cases they do not provide additional value and use up the bandwidth.

Besides that. I might be general enough to cover domain blacklisting: #489  