### PR TITLE
sanitizes the cacheKey

### DIFF
--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -290,17 +290,17 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
     restrictedUrlPattern: null,
   };
   const cached_server = request(await new Rendertron().initialize(mockConfig));
-  const test_url = `/render/${testBase}basic-script.html`;
+  const test_url = `${testBase}basic-script.html`;
   await app.listen(1235);
   // Make a request which is not in cache
-  let res = await cached_server.get(test_url);
+  let res = await cached_server.get(`/render/${test_url}`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('document-title') !== -1);
   t.is(res.header['x-renderer'], 'rendertron');
   t.true(res.header['x-rendertron-cached'] == null);
 
   // Ensure that it is cached
-  res = await cached_server.get(test_url);
+  res = await cached_server.get(`/render/${test_url}`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('document-title') !== -1);
   t.is(res.header['x-renderer'], 'rendertron');
@@ -308,7 +308,7 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
 
   // Invalidate cache and ensure it is not cached
   res = await cached_server.get(`/invalidate/${test_url}`);
-  res = await cached_server.get(test_url);
+  res = await cached_server.get(`/render/${test_url}`);
   t.is(res.status, 200);
   t.true(res.text.indexOf('document-title') !== -1);
   t.is(res.header['x-renderer'], 'rendertron');

--- a/src/test/filesystem-cache-test.ts
+++ b/src/test/filesystem-cache-test.ts
@@ -214,7 +214,7 @@ test.serial(
     t.true(new Date(res.header['x-rendertron-cached']) <= new Date());
 
     cache.clearAllCache();
-
+    await promiseTimeout(500);
     res = await server.get('/clear-all-cache?cachedResult1');
     t.is(res.status, 200);
     t.falsy(res.header['x-rendertron-cached']);


### PR DESCRIPTION
Added URL 'sanitization' to remove `/render/` addressing #558 to memory cache

Moved logic to a function in both memory & filesystem cache

Also changed slightly to test if URL was prepended with `/render/` and only remove that.