### PR TITLE
Incognito context

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ root. Available configuration options:
 - `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
 - `cacheConfig` - an object array to specify caching options
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
-- `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 - `restrictedUrlPattern`_default `null`_ - set the restrictedUrlPattern to restrict the requests matching given regex pattern.
 
 #### cacheConfig

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -11,7 +11,6 @@ root. Available configuration options:
 - `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
 - `cacheConfig` - an object array to specify caching options
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
-- `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 
 ## cacheConfig
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,6 @@ export type Config = {
   headers: { [key: string]: string };
   puppeteerArgs: Array<string>;
   renderOnly: Array<string>;
-  closeBrowser: boolean;
   restrictedUrlPattern: string | null;
 };
 
@@ -58,7 +57,6 @@ export class ConfigManager {
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
-    closeBrowser: false,
     restrictedUrlPattern: null
   };
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -91,7 +91,8 @@ export class Renderer {
       }
     }
 
-    const page = await this.browser.newPage();
+    const ctx = await this.browser.createIncognitoBrowserContext();
+    const page = await ctx.newPage();
 
     // Page may reload when setting isMobile
     // https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagesetviewportviewport
@@ -126,7 +127,6 @@ export class Renderer {
     page.evaluateOnNewDocument('ShadyCSS = {shimcssproperties: true}');
 
     await page.setRequestInterception(true);
-
     page.addListener('request', (interceptedRequest: puppeteer.Request) => {
       if (this.restrictRequest(interceptedRequest.url())) {
         interceptedRequest.abort();
@@ -161,9 +161,6 @@ export class Renderer {
       // This should only occur when the page is about:blank. See
       // https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md#pagegotourl-options.
       await page.close();
-      if (this.config.closeBrowser) {
-        await this.browser.close();
-      }
       return { status: 400, customHeaders: new Map(), content: '' };
     }
 
@@ -171,9 +168,6 @@ export class Renderer {
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response.headers()['metadata-flavor'] === 'Google') {
       await page.close();
-      if (this.config.closeBrowser) {
-        await this.browser.close();
-      }
       return { status: 403, customHeaders: new Map(), content: '' };
     }
 
@@ -230,9 +224,6 @@ export class Renderer {
     const result = (await page.content()) as string;
 
     await page.close();
-    if (this.config.closeBrowser) {
-      await this.browser.close();
-    }
     return {
       status: statusCode,
       customHeaders: customHeaders
@@ -291,9 +282,6 @@ export class Renderer {
 
     if (!response) {
       await page.close();
-      if (this.config.closeBrowser) {
-        await this.browser.close();
-      }
       throw new ScreenshotError('NoResponse');
     }
 
@@ -301,9 +289,6 @@ export class Renderer {
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response.headers()['metadata-flavor'] === 'Google') {
       await page.close();
-      if (this.config.closeBrowser) {
-        await this.browser.close();
-      }
       throw new ScreenshotError('Forbidden');
     }
 
@@ -316,9 +301,6 @@ export class Renderer {
     // https://github.com/GoogleChrome/puppeteer/blob/v1.8.0/docs/api.md#pagescreenshotoptions
     const buffer = (await page.screenshot(screenshotOptions)) as Buffer;
     await page.close();
-    if (this.config.closeBrowser) {
-      await this.browser.close();
-    }
     return buffer;
   }
 }

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -253,7 +253,6 @@ test('whitelist ensures other urls do not get rendered', async (t: ExecutionCont
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [testBase],
-    closeBrowser: false,
     restrictedUrlPattern: null,
   };
   const server = request(await new Rendertron().initialize(mockConfig));
@@ -286,7 +285,6 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
-    closeBrowser: false,
     restrictedUrlPattern: null,
   };
   const cached_server = request(await new Rendertron().initialize(mockConfig));
@@ -332,7 +330,6 @@ test('endpont for invalidating filesystem cache works if configured', async (t: 
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
-    closeBrowser: false,
     restrictedUrlPattern: null,
   };
   const cached_server = request(await new Rendertron().initialize(mock_config));
@@ -383,7 +380,6 @@ test('http header should be set via config', async (t: ExecutionContext) => {
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
-    closeBrowser: false,
     restrictedUrlPattern: null,
   };
   server = request(await rendertron.initialize(mock_config));
@@ -413,7 +409,6 @@ test.serial(
       headers: {},
       puppeteerArgs: ['--no-sandbox'],
       renderOnly: [],
-      closeBrowser: false,
       restrictedUrlPattern: null,
     };
     const cached_server = request(
@@ -466,7 +461,6 @@ test.serial(
       },
       puppeteerArgs: ['--no-sandbox'],
       renderOnly: [],
-      closeBrowser: false,
       restrictedUrlPattern: null,
     };
     const cached_server = request(
@@ -545,7 +539,6 @@ test('urls mathing pattern are restricted', async (t) => {
     },
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
-    closeBrowser: false,
     restrictedUrlPattern: '.*(\\.test.html)($|\\?)',
   };
   const cached_server = request(


### PR DESCRIPTION
This should fix a few things in one go:

- Uses an incognito context for each render, avoiding statefulness issues
- Should get rid of service workers messing with things
- Makes `closeBrowser` option obsolete
- Should fix #569 