### PR TITLE
Uses ServiceWorker.unregister to solve issues setRequestInterception(true) issues

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -151,6 +151,7 @@ export class Renderer {
       const parsedUrl = url.parse(requestUrl);
       await client.send('ServiceWorker.enable');
       await client.send('ServiceWorker.unregister', { scopeURL: `${parsedUrl.protocol}//${parsedUrl.hostname}` });
+      await client.send('Network.clearBrowserCookies')
       response = await page.goto(requestUrl, {
         timeout: this.config.timeout,
         waitUntil: 'networkidle0',
@@ -286,6 +287,7 @@ export class Renderer {
       const parsedUrl = url.parse(screenshotUrl);
       await client.send('ServiceWorker.enable');
       await client.send('ServiceWorker.unregister', { scopeURL: `${parsedUrl.protocol}//${parsedUrl.hostname}` });
+      await client.send('Network.clearBrowserCookies')
       // Navigate to page. Wait until there are no oustanding network requests.
       response = await page.goto(screenshotUrl, {
         timeout: this.config.timeout,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -165,9 +165,6 @@ export class Renderer {
       // This should only occur when the page is about:blank. See
       // https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md#pagegotourl-options.
       await page.close();
-      if (this.config.closeBrowser) {
-        await this.browser.close();
-      }
       return { status: 400, customHeaders: new Map(), content: '' };
     }
 
@@ -175,9 +172,6 @@ export class Renderer {
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response.headers()['metadata-flavor'] === 'Google') {
       await page.close();
-      if (this.config.closeBrowser) {
-        await this.browser.close();
-      }
       return { status: 403, customHeaders: new Map(), content: '' };
     }
 
@@ -234,9 +228,6 @@ export class Renderer {
     const result = (await page.content()) as string;
 
     await page.close();
-    if (this.config.closeBrowser) {
-      await this.browser.close();
-    }
     return {
       status: statusCode,
       customHeaders: customHeaders
@@ -299,9 +290,6 @@ export class Renderer {
 
     if (!response) {
       await page.close();
-      if (this.config.closeBrowser) {
-        await this.browser.close();
-      }
       throw new ScreenshotError('NoResponse');
     }
 
@@ -309,9 +297,6 @@ export class Renderer {
     // https://cloud.google.com/compute/docs/storing-retrieving-metadata.
     if (response.headers()['metadata-flavor'] === 'Google') {
       await page.close();
-      if (this.config.closeBrowser) {
-        await this.browser.close();
-      }
       throw new ScreenshotError('Forbidden');
     }
 
@@ -324,9 +309,6 @@ export class Renderer {
     // https://github.com/GoogleChrome/puppeteer/blob/v1.8.0/docs/api.md#pagescreenshotoptions
     const buffer = (await page.screenshot(screenshotOptions)) as Buffer;
     await page.close();
-    if (this.config.closeBrowser) {
-      await this.browser.close();
-    }
     return buffer;
   }
 }


### PR DESCRIPTION
Did some testing and this seemed to be a more reliable method of getting around the service worker issue, (less failures using jmeter to load test)

```javascript
const client = await page.target().createCDPSession();
```
&

```javascript
      const parsedUrl = url.parse(screenshotUrl);
      await client.send('ServiceWorker.enable');
      await client.send('ServiceWorker.unregister', { scopeURL: `${parsedUrl.protocol}//${parsedUrl.hostname}` });
      await client.send('Network.clearBrowserCookies') 
```

Also clears cookies.

PR more to share theory, please close if inappropriate!