### PR TITLE
[Feature] Add hooks for puppeteer page life cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ root. Available configuration options:
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
 - `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 - `restrictedUrlPattern`_default `null`_ - set the restrictedUrlPattern to restrict the requests matching given regex pattern.
+- `puppeteer` _default `{}`_ - an object to specify custom scripts to be executed during puppeteer page life cycle.
 
 #### cacheConfig
 
@@ -234,6 +235,21 @@ An example config file specifying a memory cache, with a 2 hour expiration, and 
         "cacheDurationMinutes": 120,
         "cacheMaxEntries": 50
     }
+}
+```
+
+#### puppeteer config ####
+Currently only supports:
+  - `evaluateOnNewDocument` - inline script/function that is invoked after the document was created but before any of its scripts were run. You can use this as a hook to initialize/bootstrap any custom logic/state needed by the page. See [puppeteer.evaluateOnNewDocument](https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-pageevaluateonnewdocumentpagefunction-args)
+  - `beforeSerialize` - path to a custom JS script that will be executed before the page is serialized by rendertron. The path is relative to rendertron root folder or can be absolute path.
+
+##### Example
+Some CSS in JS frameworks (e.g styled-components), use insertRule to add styles to the page. These styles are not present in the DOM and don't make it into the cached HTML. Leading to issues like [styled-components#2577](https://github.com/styled-components/styled-components/issues/2577). You can use `evaluateOnNewDocument` to setup [global options](https://github.com/styled-components/styled-components/issues/2577#issuecomment-497815931) for these frameworks OR use `beforeSerialize` to inject [custom script](./test-resources/cssom-to-styles.js) to convert in-memory CSSOM to inline styles.
+
+```javascript
+"puppeteer": {
+    "evaluateOnNewDocument": "SC_DISABLE_SPEEDY = true;",
+    "beforeSerialize": "./cssom-to-styles.js"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ An example config file specifying a memory cache, with a 2 hour expiration, and 
 ```
 
 #### puppeteer config ####
-Currently only supports:
+Note, this currently only supports:
   - `evaluateOnNewDocument` - inline script/function that is invoked after the document was created but before any of its scripts were run. You can use this as a hook to initialize/bootstrap any custom logic/state needed by the page. See [puppeteer.evaluateOnNewDocument](https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-pageevaluateonnewdocumentpagefunction-args)
   - `beforeSerialize` - path to a custom JS script that will be executed before the page is serialized by rendertron. The path is relative to rendertron root folder or can be absolute path.
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -12,6 +12,7 @@ root. Available configuration options:
 - `cacheConfig` - an object array to specify caching options
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
 - `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
+- `puppeteer` _default `{}`_ - an object to specify custom scripts to be executed during puppeteer page life cycle.
 
 ## cacheConfig
 
@@ -30,5 +31,20 @@ An example config file specifying a memory cache, with a 2 hour expiration, and 
         "cacheDurationMinutes": 120,
         "cacheMaxEntries": 50
     }
+}
+```
+## puppeteer config
+Currently only supports:
+  - `evaluateOnNewDocument` - inline script/function that is invoked after the document was created but before any of its scripts were run. You can use this as a hook to initialize/bootstrap any custom logic/state needed by the page. See [puppeteer.evaluateOnNewDocument](https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-pageevaluateonnewdocumentpagefunction-args)
+  - `beforeSerialize` - path to a custom JS script that will be executed before the page is serialized by rendertron. The path is relative to rendertron root folder or can be absolute path.
+
+### Example
+
+Some CSS in JS frameworks (e.g styled-components), use insertRule to add styles to the page. These styles are not present in the DOM and don't make it into the cached HTML. Leading to issues like [styled-components#2577](https://github.com/styled-components/styled-components/issues/2577). You can use `evaluateOnNewDocument` to setup [global options](https://github.com/styled-components/styled-components/issues/2577#issuecomment-497815931) for these frameworks OR use `beforeSerialize` to inject [custom script](./test-resources/cssom-to-styles.js) to convert in-memory CSSOM to inline styles.
+
+```javascript
+"puppeteer": {
+    "evaluateOnNewDocument": "SC_DISABLE_SPEEDY = true;",
+    "beforeSerialize": "./cssom-to-styles.js"
 }
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ export type Config = {
   renderOnly: Array<string>;
   closeBrowser: boolean;
   restrictedUrlPattern: string | null;
+  puppeteer: { [key: string]: string };
 };
 
 export class ConfigManager {
@@ -59,7 +60,8 @@ export class ConfigManager {
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
     closeBrowser: false,
-    restrictedUrlPattern: null
+    restrictedUrlPattern: null,
+    puppeteer: {}
   };
 
   static async getConfiguration(): Promise<Config> {

--- a/test-resources/cssom-to-styles.js
+++ b/test-resources/cssom-to-styles.js
@@ -1,0 +1,31 @@
+var cssStyles = '';
+for (let i = 0; i < document.styleSheets.length; i++) {
+    let style = null;
+    let styleSheet = document.styleSheets[i];
+    if (styleSheet.href == null && styleSheet.ownerNode.textContent == '') {
+        style = styleSheet.rules;
+    }
+    for (let item in style) {
+        if (style[item].cssText != undefined) {
+            cssStyles += style[item].cssText;
+        }
+    }
+}
+var head = document.head || document.getElementsByTagName('head')[0];
+var style = document.getElementById('styles-for-prerender');
+if (style) {
+    style.setAttribute(
+        'iteration',
+        parseInt(style.getAttribute('iteration')) + 1
+    );
+    while (style.firstChild) {
+        style.removeChild(style.firstChild);
+    }
+} else {
+    style = document.createElement('style');
+    style.setAttribute('iteration', '1');
+    head.appendChild(style);
+    style.id = 'styles-for-prerender';
+    style.type = 'text/css';
+}
+style.appendChild(document.createTextNode(cssStyles));

--- a/test-resources/cssom.html
+++ b/test-resources/cssom.html
@@ -1,0 +1,32 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<!DOCTYPE html>
+<html>
+
+<head>
+    <style id="app-styles"></style>
+    <script>
+        var styleEl = document.getElementById('app-styles');
+        // Grab style element's sheet
+        var styleSheet = styleEl.sheet;
+        // Insert CSS Rule
+        styleSheet.insertRule('body.grey { background-color: grey }', 0);
+    </script>
+</head>
+
+<body class="grey"></body>
+
+</html>

--- a/test-resources/custom-evaluate.html
+++ b/test-resources/custom-evaluate.html
@@ -1,0 +1,20 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<script>
+  var element = document.createElement('title');
+  element.textContent = window.globalTitle;
+  document.head.appendChild(element);
+</script>

--- a/test-resources/preload.js
+++ b/test-resources/preload.js
@@ -1,0 +1,31 @@
+var cssStyles = '';
+for (let i = 0; i < document.styleSheets.length; i++) {
+    let style = null;
+    let styleSheet = document.styleSheets[i];
+    if (styleSheet.href == null && styleSheet.ownerNode.textContent == '') {
+        style = styleSheet.rules;
+    }
+    for (let item in style) {
+        if (style[item].cssText != undefined) {
+            cssStyles += style[item].cssText;
+        }
+    }
+}
+var head = document.head || document.getElementsByTagName('head')[0];
+var style = document.getElementById('styles-for-prerender');
+if (style) {
+    style.setAttribute(
+        'iteration',
+        parseInt(style.getAttribute('iteration')) + 1
+    );
+    while (style.firstChild) {
+        style.removeChild(style.firstChild);
+    }
+} else {
+    style = document.createElement('style');
+    style.setAttribute('iteration', '1');
+    head.appendChild(style);
+    style.id = 'styles-for-prerender';
+    style.type = 'text/css';
+}
+style.appendChild(document.createTextNode(cssStyles));


### PR DESCRIPTION
### Why 
I noticed that Rendertron currently does not handle CSSOM that are injected on the page using [insertRule]( https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule). As these CSS rules are added to the browsers memory and do not make it in DOM, Rendertron can't serialize/save these styles in the generated snapshot. 

### Examples of the issue
There are few reports of these kind of issues #291 , [styled-components#2577](https://github.com/styled-components/styled-components/issues/2577), [prerender#574](https://github.com/prerender/prerender/issues/574).

### Changes proposed
This PR proposes to add puppeteer config section to the config file.  The config will support `evaluateOnNewDocument` and `beforeSerialize`

```
    "puppeteer": {
        "evaluateOnNewDocument": "SC_DISABLE_SPEEDY = true;",
        "beforeSerialize": "./test-resources/cssom-to-styles.js"
    }
```

#### puppeteer config
Currently only supports:
  - `evaluateOnNewDocument` - inline script/function that is invoked after the document was created but before any of its scripts were run. You can use this as a hook to initialize/bootstrap any custom logic/state needed by the page. See [puppeteer.evaluateOnNewDocument](https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-pageevaluateonnewdocumentpagefunction-args)
  - `beforeSerialize` - path to a custom JS script that will be executed before the page is serialized by rendertron. The path is relative to rendertron root folder or can be absolute path.


### Potential future extension
With the `puppeteer` config section, it will be possible to expose/support more puppeteer configurations/customizations in future. 

### README and Docs
Included in this PR also are the updates to the README and configuration.md files.

### Test cases 
Added 2 test cases to validate the working of `evaluateOnNewDocument` and `beforeSerialize` configuration.