### PR TITLE
Document Clear All Cache API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ GET /invalidate/<url>
 
 The `invalidate` endpoint will remove cache entried for `<url>` from the configured cache (in-memory, filesystem or cloud datastore).
 
+If you want to clear the entire cache, omit the `/<url>` i.e.
+```
+GET /invalidate
+```
+
 ## FAQ
 
 ### Query parameters

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -42,6 +42,12 @@ Removes the cached response for a given URL from the cache.
 | ----- | -------- | ------------------------------------ |
 | `url` | `String` | A valid URL to remove from the cache |
 
+`/invalidate`
+
+| param | type     | description                          |
+| ----- | -------- | ------------------------------------ |
+| `url` | `String` | A valid URL to remove from the cache |
+
 `/_ah/health`
 
 Returns HTTP 200 and text "OK", if the Rendertron server is healthy.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -44,9 +44,8 @@ Removes the cached response for a given URL from the cache.
 
 `/invalidate`
 
-| param | type     | description                          |
-| ----- | -------- | ------------------------------------ |
-| `url` | `String` | A valid URL to remove from the cache |
+Removes all cached responses from the cache.
+
 
 `/_ah/health`
 


### PR DESCRIPTION
Adds information on the `GET /invalidate` API for clearing the entire cache.

Addresses #691 