### PR TITLE
Enable to add any Koa middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ root. Available configuration options:
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
 - `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 - `restrictedUrlPattern`_default `null`_ - set the restrictedUrlPattern to restrict the requests matching given regex pattern.
+- `koaMiddlewares` default `[koaLogger(), koaCompress(), bodyParser()]` - set the array of [Koa middleware](https://github.com/koajs/koa/blob/master/docs/guide.md). If you want to set this, you need to specify config when calling `rendertron.initialize` instead of using `config.json`.
 
 #### cacheConfig
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,10 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
+import Koa from 'koa';
+import bodyParser from 'koa-bodyparser';
+import koaCompress from 'koa-compress';
+import koaLogger from 'koa-logger';
 
 const CONFIG_PATH = path.resolve(__dirname, '../config.json');
 
@@ -39,6 +43,7 @@ export type Config = {
   renderOnly: Array<string>;
   closeBrowser: boolean;
   restrictedUrlPattern: string | null;
+  koaMiddlewares: Array<Koa.Middleware>;
 };
 
 export class ConfigManager {
@@ -59,7 +64,12 @@ export class ConfigManager {
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
     closeBrowser: false,
-    restrictedUrlPattern: null
+    restrictedUrlPattern: null,
+    koaMiddlewares: [
+      koaLogger(),
+      koaCompress(),
+      bodyParser(),
+    ],
   };
 
   static async getConfiguration(): Promise<Config> {

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -1,9 +1,6 @@
 import Koa from 'koa';
-import bodyParser from 'koa-bodyparser';
-import koaCompress from 'koa-compress';
 import route from 'koa-route';
 import koaSend from 'koa-send';
-import koaLogger from 'koa-logger';
 import path from 'path';
 import puppeteer from 'puppeteer';
 import url from 'url';
@@ -41,11 +38,9 @@ export class Rendertron {
 
     await this.createRenderer(this.config);
 
-    this.app.use(koaLogger());
-
-    this.app.use(koaCompress());
-
-    this.app.use(bodyParser());
+    this.config.koaMiddlewares.forEach((middleware) => {
+      this.app.use(middleware);
+    });
 
     this.app.use(
       route.get('/', async (ctx: Koa.Context) => {

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -254,6 +254,7 @@ test('whitelist ensures other urls do not get rendered', async (t: ExecutionCont
     renderOnly: [testBase],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    koaMiddlewares: [],
   };
   const server = request(await new Rendertron().initialize(mockConfig));
 
@@ -287,6 +288,7 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    koaMiddlewares: [],
   };
   const cached_server = request(await new Rendertron().initialize(mockConfig));
   const test_url = `${testBase}basic-script.html`;
@@ -333,6 +335,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t: 
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    koaMiddlewares: [],
   };
   const cached_server = request(await new Rendertron().initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;
@@ -384,6 +387,7 @@ test('http header should be set via config', async (t: ExecutionContext) => {
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    koaMiddlewares: [],
   };
   server = request(await rendertron.initialize(mock_config));
   await app.listen(1237);
@@ -414,6 +418,7 @@ test.serial(
       renderOnly: [],
       closeBrowser: false,
       restrictedUrlPattern: null,
+      koaMiddlewares: [],
     };
     const cached_server = request(
       await new Rendertron().initialize(mock_config)
@@ -467,6 +472,7 @@ test.serial(
       renderOnly: [],
       closeBrowser: false,
       restrictedUrlPattern: null,
+      koaMiddlewares: [],
     };
     const cached_server = request(
       await new Rendertron().initialize(mock_config)
@@ -546,6 +552,7 @@ test('urls mathing pattern are restricted', async (t) => {
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: '.*(\\.test.html)($|\\?)',
+    koaMiddlewares: [],
   };
   const cached_server = request(
     await new Rendertron().initialize(mock_config)


### PR DESCRIPTION
I implemented this PR to resolve https://github.com/GoogleChrome/rendertron/issues/735 .
I moved the fixed middlewares to `Config Manager.config` as the default value. And each developer can override these.

## How to use this PR change?
e.g.

```javascript
import { Rendertron } from "rendertron";
import { ConfigManager } from "./config";
import bodyParser from 'koa-bodyparser';
import koaCompress from 'koa-compress';
import koaBunyanLogger from 'koa-bunyan-logger';

const config = Object.assign(ConfigManager.config, {
  koaMiddlewares: [
    koaBunyanLogger(),
    koaBunyanLogger.requestLogger(),
    bodyParser(),
    koaCompress(),
  ],
})

const rendertron = new Rendertron();
rendertron.initialize(config);
```