### PR TITLE
[FEATURE] Allow support for waitUntil configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ root. Available configuration options:
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
 - `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 - `restrictedUrlPattern`_default `null`_ - set the restrictedUrlPattern to restrict the requests matching given regex pattern.
-
+- `waitUntil`_default `networkidle0`_ - set the waitUntil to when to consider navigation succeeded
 #### cacheConfig
 
 - `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
+import { PuppeteerLifeCycleEvent } from 'puppeteer';
 
 const CONFIG_PATH = path.resolve(__dirname, '../config.json');
 
@@ -39,6 +40,7 @@ export type Config = {
   renderOnly: Array<string>;
   closeBrowser: boolean;
   restrictedUrlPattern: string | null;
+  waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[]
 };
 
 export class ConfigManager {
@@ -59,7 +61,8 @@ export class ConfigManager {
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
     closeBrowser: false,
-    restrictedUrlPattern: null
+    restrictedUrlPattern: null,
+    waitUntil: 'networkidle0'
   };
 
   static async getConfiguration(): Promise<Config> {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -150,7 +150,7 @@ export class Renderer {
       // Navigate to page. Wait until there are no oustanding network requests.
       response = await page.goto(requestUrl, {
         timeout: this.config.timeout,
-        waitUntil: 'networkidle0',
+        waitUntil: this.config.waitUntil,
       });
     } catch (e) {
       console.error(e);
@@ -283,7 +283,7 @@ export class Renderer {
       // Navigate to page. Wait until there are no oustanding network requests.
       response = await page.goto(url, {
         timeout: this.config.timeout,
-        waitUntil: 'networkidle0',
+        waitUntil: this.config.waitUntil,
       });
     } catch (e) {
       console.error(e);

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -23,6 +23,7 @@ import fs from 'fs';
 import os from 'os';
 
 import { Rendertron } from '../rendertron';
+import { Config } from '../config';
 
 const app = new Koa();
 app.use(koaStatic(path.resolve(__dirname, '../../test-resources')));
@@ -237,7 +238,7 @@ test.failing(
 );
 
 test('whitelist ensures other urls do not get rendered', async (t: ExecutionContext) => {
-  const mockConfig = {
+  const mockConfig: Config = {
     cache: 'memory' as const,
     cacheConfig: {
       cacheDurationMinutes: '120',
@@ -254,6 +255,7 @@ test('whitelist ensures other urls do not get rendered', async (t: ExecutionCont
     renderOnly: [testBase],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    waitUntil: 'networkidle0',
   };
   const server = request(await new Rendertron().initialize(mockConfig));
 
@@ -270,7 +272,7 @@ test('unknown url fails safely on screenshot', async (t: ExecutionContext) => {
 });
 
 test('endpont for invalidating memory cache works if configured', async (t: ExecutionContext) => {
-  const mockConfig = {
+  const mockConfig: Config = {
     cache: 'memory' as const,
     cacheConfig: {
       cacheDurationMinutes: '120',
@@ -287,6 +289,7 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    waitUntil: 'networkidle0',
   };
   const cached_server = request(await new Rendertron().initialize(mockConfig));
   const test_url = `${testBase}basic-script.html`;
@@ -315,7 +318,7 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
 });
 
 test('endpont for invalidating filesystem cache works if configured', async (t: ExecutionContext) => {
-  const mock_config = {
+  const mock_config: Config = {
     cache: 'filesystem' as const,
     cacheConfig: {
       cacheDurationMinutes: '120',
@@ -333,6 +336,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t: 
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    waitUntil: 'networkidle0',
   };
   const cached_server = request(await new Rendertron().initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;
@@ -365,7 +369,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t: 
 });
 
 test('http header should be set via config', async (t: ExecutionContext) => {
-  const mock_config = {
+  const mock_config: Config = {
     cache: 'memory' as const,
     cacheConfig: {
       cacheDurationMinutes: '120',
@@ -384,6 +388,7 @@ test('http header should be set via config', async (t: ExecutionContext) => {
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    waitUntil: 'networkidle0',
   };
   server = request(await rendertron.initialize(mock_config));
   await app.listen(1237);
@@ -395,7 +400,7 @@ test('http header should be set via config', async (t: ExecutionContext) => {
 test.serial(
   'endpoint for invalidating all memory cache works if configured',
   async (t: ExecutionContext) => {
-    const mock_config = {
+    const mock_config: Config = {
       cache: 'memory' as const,
       cacheConfig: {
         cacheDurationMinutes: '120',
@@ -414,6 +419,7 @@ test.serial(
       renderOnly: [],
       closeBrowser: false,
       restrictedUrlPattern: null,
+      waitUntil: 'networkidle0',
     };
     const cached_server = request(
       await new Rendertron().initialize(mock_config)
@@ -447,7 +453,7 @@ test.serial(
 test.serial(
   'endpoint for invalidating all filesystem cache works if configured',
   async (t: ExecutionContext) => {
-    const mock_config = {
+    const mock_config: Config = {
       cache: 'filesystem' as const,
       cacheConfig: {
         cacheDurationMinutes: '120',
@@ -467,6 +473,7 @@ test.serial(
       renderOnly: [],
       closeBrowser: false,
       restrictedUrlPattern: null,
+      waitUntil: 'networkidle0',
     };
     const cached_server = request(
       await new Rendertron().initialize(mock_config)
@@ -526,7 +533,7 @@ test('known timezone applies', async (t) => {
 });
 
 test('urls mathing pattern are restricted', async (t) => {
-  const mock_config = {
+  const mock_config: Config = {
     cache: 'filesystem' as const,
     cacheConfig: {
       cacheDurationMinutes: '120',
@@ -546,6 +553,7 @@ test('urls mathing pattern are restricted', async (t) => {
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: '.*(\\.test.html)($|\\?)',
+    waitUntil: 'networkidle0'
   };
   const cached_server = request(
     await new Rendertron().initialize(mock_config)


### PR DESCRIPTION
I implemented this PR to resolve #754  .
Added the `waitUntil` option for the rendertron configuration.

### How to use the configuration update:
(config.json)
```json
{
    ...
    "waitUntil": [
        "domcontentloaded",
        "networkidle2"
    ]
}
````