### PR TITLE
[FEATURE] Added config option to increase logs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ export type Config = {
   renderOnly: Array<string>;
   closeBrowser: boolean;
   restrictedUrlPattern: string | null;
+  renderLogOptions: Array<string>;
 };
 
 export class ConfigManager {
@@ -59,7 +60,8 @@ export class ConfigManager {
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
     closeBrowser: false,
-    restrictedUrlPattern: null
+    restrictedUrlPattern: null,
+    renderLogOptions: [],
   };
 
   static async getConfiguration(): Promise<Config> {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -145,6 +145,32 @@ export class Renderer {
         response = r;
       }
     });
+  
+    if (this.config.renderLogOptions.includes("console")) {
+      page
+        .on('console', async msg => {
+          const args = await msg.args()
+          args.forEach(async (arg) => {
+            const val = await arg.jsonValue()
+            // value is serializable
+            if (JSON.stringify(val) !== JSON.stringify({})) console.log(val)
+            // value is unserializable (or an empty oject)
+            else {
+              const { type, subtype, description } = arg._remoteObject
+              console.log(`type: ${type}, subtype: ${subtype}, description:\n ${description}`)
+            }
+          })
+        })
+    
+      if (this.config.renderLogOptions.includes("pageerror")) { page.on('pageerror', ({ message }) => console.log(message)) }
+      if (this.config.renderLogOptions.includes("response")) { page.on('response', response => console.log(`${response.status()} ${response.url()}`)) }
+      if (this.config.renderLogOptions.includes("requestfailed")) {
+        page.on('requestfailed', request => {
+          const failureResult = request.failure();
+          if (failureResult) console.log(`${failureResult.errorText} ${request.url()}`)
+        })
+      }
+    }
 
     try {
       // Navigate to page. Wait until there are no oustanding network requests.

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -254,6 +254,7 @@ test('whitelist ensures other urls do not get rendered', async (t: ExecutionCont
     renderOnly: [testBase],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    renderLogOptions: [],
   };
   const server = request(await new Rendertron().initialize(mockConfig));
 
@@ -287,6 +288,7 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    renderLogOptions: [],
   };
   const cached_server = request(await new Rendertron().initialize(mockConfig));
   const test_url = `${testBase}basic-script.html`;
@@ -333,6 +335,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t: 
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    renderLogOptions: [],
   };
   const cached_server = request(await new Rendertron().initialize(mock_config));
   const test_url = `/render/${testBase}basic-script.html`;
@@ -384,6 +387,7 @@ test('http header should be set via config', async (t: ExecutionContext) => {
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: null,
+    renderLogOptions: [],
   };
   server = request(await rendertron.initialize(mock_config));
   await app.listen(1237);
@@ -414,6 +418,7 @@ test.serial(
       renderOnly: [],
       closeBrowser: false,
       restrictedUrlPattern: null,
+      renderLogOptions: [],
     };
     const cached_server = request(
       await new Rendertron().initialize(mock_config)
@@ -467,6 +472,7 @@ test.serial(
       renderOnly: [],
       closeBrowser: false,
       restrictedUrlPattern: null,
+      renderLogOptions: [],
     };
     const cached_server = request(
       await new Rendertron().initialize(mock_config)
@@ -546,6 +552,7 @@ test('urls mathing pattern are restricted', async (t) => {
     renderOnly: [],
     closeBrowser: false,
     restrictedUrlPattern: '.*(\\.test.html)($|\\?)',
+    renderLogOptions: [],
   };
   const cached_server = request(
     await new Rendertron().initialize(mock_config)


### PR DESCRIPTION
Why? 
- there is no way to see javascript logs when a page is pre-rendered. If a particular bug only happens when pre-rendered, it's not possible to see what the logs say. This includes errors, simple console.log-s, network errors, etc. 

Solution
- a configuration array where you can select what to log out

Options: 
- console, pageerror, response, requestfailed

If no option is given, the default rendertron logging is the only one applied.

Please let me know if you want also the documentation updated, as it'd require a small change there with the new config settings. 