### PR TITLE
fix: base url null

### DIFF
--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -138,10 +138,27 @@ export class Rendertron {
     return true;
   }
 
+  handleFixProtocol(href: string) {
+    if (href.startsWith('https://') || href.startsWith('https://') ) {
+        return href;
+    } else {
+        
+        const parsedUrl = url.parse(href);
+        
+        if (!parsedUrl.host) {
+                return parsedUrl.protocol + '/' + parsedUrl.path;
+        } else {
+                return parsedUrl.protocol + '//' + parsedUrl.host + parsedUrl.path;
+        }
+    }
+  }
+
   async handleRenderRequest(ctx: Koa.Context, url: string) {
     if (!this.renderer) {
       throw new Error('No renderer initalized yet.');
     }
+
+    url = this.handleFixProtocol(url);
 
     if (this.restricted(url)) {
       ctx.status = 403;


### PR DESCRIPTION
based in that issue: https://stackoverflow.com/questions/59275646/base-routes-are-always-empty-with-rendertron.

I could detect that a slash corresponding to the protocol in the initialization is removed from the url

this.app.use(
       route.get('/render/:url(.*)', this.handleRenderRequest.bind(this)));
I solved it by adding the following method in the rendertron class and calling it from the handleRenderRequest method

handleFixProtocol(href: string) {
    if (href.startsWith('https://') || href.startsWith('https://') ) {
      return href;
      } else {
        const parsedUrl = url.parse(href);
        if (!parsedUrl.host) {
          return parsedUrl.protocol + '/' + parsedUrl.path;
        } else {
          return parsedUrl.protocol + '//' + parsedUrl.host + parsedUrl.path;
        }
    }
   }
async handleRenderRequest(ctx: Koa.Context, url: string) {
    if (!this.renderer) {
      throw (new Error('No renderer initalized yet.'));
    }

    url = this.handleFixProtocol(url);